### PR TITLE
ChatLib.getCenteredText(input) now returns input if it is too long

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/libs/ChatLib.java
+++ b/src/main/java/com/chattriggers/ctjs/libs/ChatLib.java
@@ -159,6 +159,10 @@ public class ChatLib {
         StringBuilder stringBuilder = new StringBuilder(input);
         FontRenderer fRenderer = Minecraft.getMinecraft().fontRendererObj;
 
+        if (fRenderer.getStringWidth(stringBuilder.toString()) > Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatWidth()) {
+            return stringBuilder.toString();
+        }
+
         while (fRenderer.getStringWidth(stringBuilder.toString()) < Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatWidth()) {
             if (left) {
                 stringBuilder.insert(0, " ");


### PR DESCRIPTION
Fixes issue where, if input was too long, it would be returned with the first character deleted.