### PR TITLE
Added ct commands

### DIFF
--- a/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
+++ b/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
@@ -38,7 +38,12 @@ public class CTCommand extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/ct <reload/files/console>";
+        return "&b&m" + ChatLib.getChatBreak("-") + "\n" +
+               "&c/ct <load/reload> &b- &eReloads all of the ct imports.\n" +
+               "&c/ct files &b- &eOpens the ChatTriggers folder.\n" +
+               "&c/ct console &b- &eOpens the ct console.\n" +
+               "&c/ct &b- &eDisplays this help dialog\n" +
+               "&b&m" + ChatLib.getChatBreak("-");
     }
 
     @Override
@@ -66,11 +71,11 @@ public class CTCommand extends CommandBase {
                     Console.clear();
                     break;
                 default:
-                    ChatLib.chat(EnumChatFormatting.RED + getCommandUsage(sender));
+                    ChatLib.chat(getCommandUsage(sender));
                     break;
             }
         } else {
-            ChatLib.chat(EnumChatFormatting.RED + getCommandUsage(sender));
+            ChatLib.chat(getCommandUsage(sender));
         }
     }
 

--- a/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
+++ b/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
@@ -8,7 +8,9 @@ import com.chattriggers.ctjs.utils.console.Console;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
 
 import javax.script.ScriptEngine;
 import java.awt.*;
@@ -70,6 +72,9 @@ public class CTCommand extends CommandBase {
                     Console.getConsole().showConsole(true);
                     Console.clear();
                     break;
+                case("simulate"):
+                    simulateChat(args);
+                    break;
                 default:
                     ChatLib.chat(getCommandUsage(sender));
                     break;
@@ -79,6 +84,21 @@ public class CTCommand extends CommandBase {
         }
     }
 
+
+    private void simulateChat(String[] args) {
+        StringBuilder toSend = new StringBuilder();
+
+        for (int i = 1; i < args.length; i++) {
+            toSend.append(args[i]).append(" ");
+        }
+
+        ClientChatReceivedEvent event = new ClientChatReceivedEvent((byte) 0, new ChatComponentText(toSend.toString()));
+        CTJS.getInstance().getChatListener().onReceiveChat(event);
+
+        if (!event.isCanceled()) {
+            ChatLib.chat(event.message.getFormattedText());
+        }
+    }
 
     // Open the folder containing all of ChatTrigger's files
     private void openFileLocation() {

--- a/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
+++ b/src/main/java/com/chattriggers/ctjs/commands/CTCommand.java
@@ -54,6 +54,8 @@ public class CTCommand extends CommandBase {
                "&c/ct <load/reload> &b- &eReloads all of the ct imports.\n" +
                "&c/ct files &b- &eOpens the ChatTriggers folder.\n" +
                "&c/ct console &b- &eOpens the ct console.\n" +
+               "&c/ct simulate &b- &eSimulates a received chat message.\n" +
+               "&c/ct dump &b- &eDumps previous chat messages into chat, showing color codes.\n" +
                "&c/ct &b- &eDisplays this help dialog\n" +
                "&b&m" + ChatLib.getChatBreak("-");
     }

--- a/src/main/java/com/chattriggers/ctjs/libs/MinecraftVars.java
+++ b/src/main/java/com/chattriggers/ctjs/libs/MinecraftVars.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.chunk.Chunk;
@@ -408,9 +409,11 @@ public class MinecraftVars {
      * @return The player's active potion effects.
      */
     public static String[] getActivePotionEffects(){
-        ArrayList<String> effects = new Arraylist<String>();
-        for(PotionEffect e : mc.thePlayer.getActivePotionEffects()){
-            effects.add(e.toString());
+        if (mc.thePlayer == null) return null;
+        
+        ArrayList<String> effects = new ArrayList<>();
+        for(PotionEffect effect : mc.thePlayer.getActivePotionEffects()){
+            effects.add(effect.toString());
         }
         return effects.toArray(new String[effects.size()]);
     }


### PR DESCRIPTION
- `/ct simulate [msg]` - Treats `msg` as if it was an actual received message.
- `/ct dump [number]` - Outputs previous chat messages to chat with color codes. Clicking them copies to clipboard. `number` defaults to 100.
- Fixed `MinecraftVars.getActivePotionEffects()`.