### PR TITLE
Fix playerLeft event not triggering on player leave.

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
@@ -135,9 +135,7 @@ object WorldListener {
         while (ite.hasNext()) {
             val it = ite.next()
 
-            try {
-                World.getPlayerByName(it)
-            } catch (exception: Exception) {
+            if (World.getPlayerByName(it) == null) {
                 this.playerList.remove(it)
                 TriggerType.PLAYER_LEAVE.triggerAll(it)
                 break


### PR DESCRIPTION
World.getPlayerByName returns null if player isn't found.