### PR TITLE
Allow for module creators to add a "helpString" to metadata

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/commands/CTCommand.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/commands/CTCommand.kt
@@ -9,6 +9,7 @@ import com.chattriggers.ctjs.minecraft.objects.gui.GuiHandler
 import com.chattriggers.ctjs.minecraft.objects.message.Message
 import com.chattriggers.ctjs.minecraft.objects.message.TextComponent
 import com.chattriggers.ctjs.print
+import com.chattriggers.ctjs.utils.config.Config
 import com.chattriggers.ctjs.utils.config.GuiConfig
 import net.minecraft.command.CommandBase
 import net.minecraft.command.CommandException
@@ -93,6 +94,9 @@ object CTCommand : CommandBase() {
                     ChatLib.chat("&cUnable to import module $moduleName")
                 } else {
                     ChatLib.chat("&aSuccessfully imported ${module.metadata.name ?: module.name}")
+                    if (Config.moduleImportHelp && module.metadata.helpMessage != null) {
+                        ChatLib.chat("${if (module.metadata.helpMessage.toString().length <= 384) module.metadata.helpMessage else module.metadata.helpMessage.toString().substring(0, 383)}")
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
@@ -13,6 +13,7 @@ data class ModuleMetadata(
     val creator: String? = null,
     val description: String? = null,
     val requires: ArrayList<String>? = null,
+    val helpMessage: String? = null,
     val ignored: ArrayList<String>? = null,
     var isRequired: Boolean = false
 ) {

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/config/Config.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/config/Config.kt
@@ -49,6 +49,9 @@ object Config {
     @ConfigOpt(name = "Threaded Loading", x = -110, y = 230, type = ConfigBoolean::class)
     var threadedLoading = true
 
+    @ConfigOpt(name = "Show Module Help on Import", x = -110, y = 285, type = ConfigBoolean::class)
+    var moduleImportHelp = true
+
     fun load(jsonObject: JsonObject) {
         val gson = Gson()
 


### PR DESCRIPTION
This string then gets printed to the user when they import the module.