### PR TITLE
Fix addPage, setPage, and display Methods

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Book.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/Book.kt
@@ -40,8 +40,7 @@ class Book(bookName: String) {
      * @return the current book to allow method chaining
      */
     fun addPage(message: Message) = apply {
-        val pages = (bookData["pages"] ?: return@apply) as NBTTagList
-
+        val pages = NBTTagList((bookData.get("pages", NBTTagCompound.NBTDataType.TAG_LIST, 8) ?: return@apply) as MCNBTTagList)
         pages.appendTag(
             MCNBTTagString(
                 TextComponentSerializer.componentToJson(
@@ -71,7 +70,7 @@ class Book(bookName: String) {
      * @return the current book to allow method chaining
      */
     fun setPage(pageNumber: Int, message: Message) = apply {
-        val pages = bookData.getTag("pages") as NBTTagList
+        val pages = NBTTagList((bookData.get("pages", NBTTagCompound.NBTDataType.TAG_LIST, 8) ?: return@apply) as MCNBTTagList)
 
         pages[pageNumber] = MCNBTTagString(
             TextComponentSerializer.componentToJson(
@@ -91,9 +90,7 @@ class Book(bookName: String) {
 
     @JvmOverloads
     fun display(page: Int = 0) {
-        if (bookScreen == null) {
-            bookScreen = GuiScreenBook(Player.getPlayer(), book, false)
-        }
+        bookScreen = GuiScreenBook(Player.getPlayer(), book, false)
 
         bookScreen!!.currPage = page
         GuiHandler.openGui(bookScreen ?: return)

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/nbt/NBTTagCompound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/nbt/NBTTagCompound.kt
@@ -25,6 +25,7 @@ class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
         INT_ARRAY,
         BOOLEAN,
         COMPOUND_TAG,
+        TAG_LIST,
     }
 
     fun getTag(key: String) = when (val tag = rawNBT.getTag(key)) {
@@ -53,9 +54,13 @@ class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
 
     fun getIntArray(key: String) = rawNBT.getIntArray(key)
 
+    fun getBoolean(key: String) = rawNBT.getBoolean(key)
+
     fun getCompoundTag(key: String) = NBTTagCompound(rawNBT.getCompoundTag(key))
 
-    fun get(key: String, type: NBTDataType): Any? {
+    fun getTagList(key: String, type: Int) = rawNBT.getTagList(key, type)
+
+    fun get(key: String, type: NBTDataType, tagType: Int?): Any? {
         return when (type) {
             NBTDataType.BYTE -> getByte(key)
             NBTDataType.SHORT -> getShort(key)
@@ -66,8 +71,9 @@ class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
             NBTDataType.STRING -> if (rawNBT.hasKey(key, 8)) (tagMap[key] as NBTBase).toString() else null
             NBTDataType.BYTE_ARRAY -> if (rawNBT.hasKey(key, 7)) (tagMap[key] as NBTTagByteArray).byteArray else null
             NBTDataType.INT_ARRAY -> if (rawNBT.hasKey(key, 11)) (tagMap[key] as NBTTagIntArray).intArray else null
-            NBTDataType.BOOLEAN -> get(key, NBTDataType.BYTE) != 0
+            NBTDataType.BOOLEAN -> getBoolean(key)
             NBTDataType.COMPOUND_TAG -> getCompoundTag(key)
+            NBTDataType.TAG_LIST -> if (tagType == null) throw IllegalArgumentException("For accessing a tag list you need to provide the tagType argument") else getTagList(key, tagType)
         }
     }
 


### PR DESCRIPTION
The addPage and setPage methods previously would crash due to a cast exception. This commit adds to the NBTTagCompound wrapper by adding support for tag lists. 

I'm really not sure I did this in the best way for the get method because it feels silly to add a whole argument for one specific case. Also the display function seemed to not properly update so that was fixed.