### PR TITLE
Renderer: Fix incorrect calculation of str length causing misalignments

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -99,7 +99,7 @@ object Renderer {
     }
 
     @JvmStatic
-    fun getStringWidth(text: String) = getFontRenderer().getStringWidth(text)
+    fun getStringWidth(text: String) = getFontRenderer().getStringWidth(ChatLib.addColor(text))
 
     @JvmStatic
     @JvmOverloads

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayHandler.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayHandler.kt
@@ -19,9 +19,7 @@ object DisplayHandler {
     fun clearDisplays() = this.displays.clear()
 
     @SubscribeEvent
-    fun renderDisplays(event: RenderGameOverlayEvent.Pre) {
-        if (event.type != RenderGameOverlayEvent.ElementType.TEXT) return
-
+    fun renderDisplays(event: RenderGameOverlayEvent.Text) {
         GL11.glPushMatrix()
         this.displays.forEach(Display::render)
         GL11.glPopMatrix()


### PR DESCRIPTION
Renderer#getStringWidth and more specifically FontRenderer#getStringWidth wasn't handling the easier to use "&" color coding resulting in incorrect width calculations.

This commit also resolves #223 which was happening as a result of the miscalculation.

Also might as well change the renderDisplay event to use RenderGameOverlayEvent.Text while I'm at it :^)