### PR TITLE
clean up crash report category

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
@@ -74,5 +74,5 @@ class Module(val name: String, var metadata: ModuleMetadata, val folder: File) {
         }
     }
 
-    override fun toString() = "Module{name=$name,folder=$folder,metadata=$metadata}"
+    override fun toString() = "Module{name=$name,version=${metadata.version}}"
 }


### PR DESCRIPTION
as far as I'm aware, `Module#toString` is only being used for adding the crash report section via ASMUtils, which ends up being really long with unneeded info like seen [here](https://i.imgur.com/omYFSRv.png)