### PR TITLE
Improved Renderer.drawPlayer

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
@@ -13,11 +13,11 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
     private var showArrows = true
 
     fun setOptions(
-            showNametag: Boolean,
-            showArmor: Boolean,
-            showCape: Boolean,
-            showHeldItem: Boolean,
-            showArrows: Boolean
+        showNametag: Boolean,
+        showArmor: Boolean,
+        showCape: Boolean,
+        showHeldItem: Boolean,
+        showArrows: Boolean
     ) {
         this.showNametag = showNametag
         this.showArmor = showArmor
@@ -43,13 +43,13 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
     override fun canRenderName(entity: AbstractClientPlayer?) = showNametag
 
     override fun renderOffsetLivingLabel(
-            entityIn: AbstractClientPlayer?,
-            x: Double,
-            y: Double,
-            z: Double,
-            str: String?,
-            p_177069_9_: Float,
-            p_177069_10_: Double
+        entityIn: AbstractClientPlayer?,
+        x: Double,
+        y: Double,
+        z: Double,
+        str: String?,
+        p_177069_9_: Float,
+        p_177069_10_: Double
     ) {
         if (showNametag) super.renderOffsetLivingLabel(entityIn, x, y, z, str, p_177069_9_, p_177069_10_)
     }
@@ -59,12 +59,12 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
     }
 
     override fun renderLivingLabel(
-            entityIn: AbstractClientPlayer?,
-            str: String?,
-            x: Double,
-            y:Double,
-            z: Double,
-            maxDistance: Int
+        entityIn: AbstractClientPlayer?,
+        str: String?,
+        x: Double,
+        y:Double,
+        z: Double,
+        maxDistance: Int
     ) {
         if (showNametag) super.renderLivingLabel(entityIn, str, x, y, z, maxDistance)
     }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
@@ -1,0 +1,84 @@
+package com.chattriggers.ctjs.minecraft.libs.renderer
+
+import net.minecraft.client.entity.AbstractClientPlayer
+import net.minecraft.client.renderer.entity.RenderManager
+import net.minecraft.client.renderer.entity.RenderPlayer
+import net.minecraft.client.renderer.entity.layers.*
+
+class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : RenderPlayer(renderManager, useSmallArms) {
+    private var showNametag = true
+    private var showArmor = true
+    private var showCape = true
+    private var showHeldItem = true
+    private var showArrows = true
+
+    fun setOptions(
+            showNametag: Boolean,
+            showArmor: Boolean,
+            showCape: Boolean,
+            showHeldItem: Boolean,
+            showArrows: Boolean
+    ) {
+        this.showNametag = showNametag
+        this.showArmor = showArmor
+        this.showCape = showCape
+        this.showHeldItem = showHeldItem
+        this.showArrows = showArrows
+
+        layerRenderers = arrayListOf<LayerRenderer<AbstractClientPlayer>>()
+
+        if(showArmor) addLayer(LayerBipedArmor(this))
+        if(showHeldItem) addLayer(LayerHeldItem(this))
+        if(showArrows) addLayer(LayerArrow(this))
+        addLayer(LayerDeadmau5Head(this))
+        if(showCape) addLayer(LayerCape(this))
+        if(showArmor) addLayer(LayerCustomHead(this.getMainModel().bipedHead))
+    }
+
+    override fun doRender(
+            entity: AbstractClientPlayer?,
+            x: Double,
+            y: Double,
+            z: Double,
+            entityYaw: Float,
+            partialTicks: Float
+    ) {
+        super.doRender(entity, x, y, z, entityYaw, partialTicks)
+    }
+
+    override fun setModelVisibilities(clientPlayer: AbstractClientPlayer) {
+        super.setModelVisibilities(clientPlayer)
+        if(!showHeldItem) getMainModel().heldItemRight = 0
+    }
+
+    override fun canRenderName(entity: AbstractClientPlayer?): Boolean {
+        return showNametag
+    }
+
+    override fun renderOffsetLivingLabel(
+            entityIn: AbstractClientPlayer?,
+            x: Double,
+            y: Double,
+            z: Double,
+            str: String?,
+            p_177069_9_: Float,
+            p_177069_10_: Double
+    ) {
+        if(showNametag) super.renderOffsetLivingLabel(entityIn, x, y, z, str, p_177069_9_, p_177069_10_)
+    }
+
+    override fun renderName(entity: AbstractClientPlayer?, x: Double, y: Double, z: Double) {
+        if(showNametag) super.renderName(entity, x, y, z)
+    }
+
+    override fun renderLivingLabel(
+            entityIn: AbstractClientPlayer?,
+            str: String?,
+            x: Double,
+            y:Double,
+            z: Double,
+            maxDistance: Int
+    ) {
+        if(showNametag) super.renderLivingLabel(entityIn, str, x, y, z, maxDistance)
+    }
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/CTRenderPlayer.kt
@@ -27,33 +27,20 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
 
         layerRenderers = arrayListOf<LayerRenderer<AbstractClientPlayer>>()
 
-        if(showArmor) addLayer(LayerBipedArmor(this))
-        if(showHeldItem) addLayer(LayerHeldItem(this))
-        if(showArrows) addLayer(LayerArrow(this))
+        if (showArmor) addLayer(LayerBipedArmor(this))
+        if (showHeldItem) addLayer(LayerHeldItem(this))
+        if (showArrows) addLayer(LayerArrow(this))
         addLayer(LayerDeadmau5Head(this))
-        if(showCape) addLayer(LayerCape(this))
-        if(showArmor) addLayer(LayerCustomHead(this.getMainModel().bipedHead))
-    }
-
-    override fun doRender(
-            entity: AbstractClientPlayer?,
-            x: Double,
-            y: Double,
-            z: Double,
-            entityYaw: Float,
-            partialTicks: Float
-    ) {
-        super.doRender(entity, x, y, z, entityYaw, partialTicks)
+        if (showCape) addLayer(LayerCape(this))
+        if (showArmor) addLayer(LayerCustomHead(this.getMainModel().bipedHead))
     }
 
     override fun setModelVisibilities(clientPlayer: AbstractClientPlayer) {
         super.setModelVisibilities(clientPlayer)
-        if(!showHeldItem) getMainModel().heldItemRight = 0
+        if (!showHeldItem) getMainModel().heldItemRight = 0
     }
 
-    override fun canRenderName(entity: AbstractClientPlayer?): Boolean {
-        return showNametag
-    }
+    override fun canRenderName(entity: AbstractClientPlayer?) = showNametag
 
     override fun renderOffsetLivingLabel(
             entityIn: AbstractClientPlayer?,
@@ -64,11 +51,11 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
             p_177069_9_: Float,
             p_177069_10_: Double
     ) {
-        if(showNametag) super.renderOffsetLivingLabel(entityIn, x, y, z, str, p_177069_9_, p_177069_10_)
+        if (showNametag) super.renderOffsetLivingLabel(entityIn, x, y, z, str, p_177069_9_, p_177069_10_)
     }
 
     override fun renderName(entity: AbstractClientPlayer?, x: Double, y: Double, z: Double) {
-        if(showNametag) super.renderName(entity, x, y, z)
+        if (showNametag) super.renderName(entity, x, y, z)
     }
 
     override fun renderLivingLabel(
@@ -79,6 +66,6 @@ class CTRenderPlayer(renderManager: RenderManager?, useSmallArms: Boolean) : Ren
             z: Double,
             maxDistance: Int
     ) {
-        if(showNametag) super.renderLivingLabel(entityIn, str, x, y, z, maxDistance)
+        if (showNametag) super.renderLivingLabel(entityIn, str, x, y, z, maxDistance)
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -8,6 +8,7 @@ import com.chattriggers.ctjs.minecraft.wrappers.objects.PlayerMP
 import com.chattriggers.ctjs.utils.kotlin.External
 import com.chattriggers.ctjs.utils.kotlin.MCTessellator
 import com.chattriggers.ctjs.utils.kotlin.getRenderer
+import net.minecraft.client.entity.AbstractClientPlayer
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
@@ -22,6 +23,7 @@ import kotlin.math.atan
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
+
 
 @External
 object Renderer {
@@ -361,9 +363,23 @@ object Renderer {
         finishDraw()
     }
 
+    private val renderMgr = Client.getMinecraft().renderManager
+    private val slimCTRenderPlayer = CTRenderPlayer(renderMgr, true)
+    private val normalCTRenderPlayer = CTRenderPlayer(renderMgr, false)
+
     @JvmStatic
     @JvmOverloads
-    fun drawPlayer(player: Any, x: Int, y: Int, rotate: Boolean = false) {
+    fun drawPlayer(
+            player: Any,
+            x: Int,
+            y: Int,
+            rotate: Boolean = false,
+            showNametag: Boolean = false,
+            showArmor: Boolean = true,
+            showCape: Boolean = true,
+            showHeldItem: Boolean = true,
+            showArrows: Boolean = true
+    ) {
         val mouseX = -30f
         val mouseY = 0f
 
@@ -385,6 +401,7 @@ object Renderer {
         GlStateManager.rotate(45.0f, 0.0f, 1.0f, 0.0f)
         GlStateManager.rotate(-45.0f, 0.0f, 1.0f, 0.0f)
         GlStateManager.rotate(-atan((mouseY / 40.0f).toDouble()).toFloat() * 20.0f, 1.0f, 0.0f, 0.0f)
+        GlStateManager.scale(-1f, 1f, 1f)
         if (!rotate) {
             ent.renderYawOffset = atan((mouseX / 40.0f).toDouble()).toFloat() * 20.0f
             ent.rotationYaw = atan((mouseX / 40.0f).toDouble()).toFloat() * 40.0f
@@ -398,7 +415,11 @@ object Renderer {
         renderManager.setPlayerViewY(180.0f)
         renderManager.isRenderShadow = false
         //#if MC<=10809
-        renderManager.renderEntityWithPosYaw(ent, 0.0, 0.0, 0.0, 0.0f, 1.0f)
+        val isSmall = (ent as AbstractClientPlayer).skinType == "slim"
+        val ctRenderPlayer = if(isSmall) slimCTRenderPlayer else normalCTRenderPlayer
+
+        ctRenderPlayer.setOptions(showNametag, showArmor, showCape, showHeldItem, showArrows)
+        ctRenderPlayer.doRender(ent, 0.0, 0.0, 0.0, 0.0f, 1.0f)
         //#else
         //$$ renderManager.doRenderEntity(ent, 0.0, 0.0, 0.0, 0.0F, 1.0F, false)
         //#endif

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -24,7 +24,6 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 
-
 @External
 object Renderer {
     var colorized: Long? = null
@@ -363,9 +362,9 @@ object Renderer {
         finishDraw()
     }
 
-    private val renderMgr = Client.getMinecraft().renderManager
-    private val slimCTRenderPlayer = CTRenderPlayer(renderMgr, true)
-    private val normalCTRenderPlayer = CTRenderPlayer(renderMgr, false)
+    private val renderManager = Client.getMinecraft().renderManager
+    private val slimCTRenderPlayer = CTRenderPlayer(renderManager, true)
+    private val normalCTRenderPlayer = CTRenderPlayer(renderManager, false)
 
     @JvmStatic
     @JvmOverloads
@@ -416,7 +415,7 @@ object Renderer {
         renderManager.isRenderShadow = false
         //#if MC<=10809
         val isSmall = (ent as AbstractClientPlayer).skinType == "slim"
-        val ctRenderPlayer = if(isSmall) slimCTRenderPlayer else normalCTRenderPlayer
+        val ctRenderPlayer = if (isSmall) slimCTRenderPlayer else normalCTRenderPlayer
 
         ctRenderPlayer.setOptions(showNametag, showArmor, showCape, showHeldItem, showArrows)
         ctRenderPlayer.doRender(ent, 0.0, 0.0, 0.0, 0.0f, 1.0f)

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -369,15 +369,15 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun drawPlayer(
-            player: Any,
-            x: Int,
-            y: Int,
-            rotate: Boolean = false,
-            showNametag: Boolean = false,
-            showArmor: Boolean = true,
-            showCape: Boolean = true,
-            showHeldItem: Boolean = true,
-            showArrows: Boolean = true
+        player: Any,
+        x: Int,
+        y: Int,
+        rotate: Boolean = false,
+        showNametag: Boolean = false,
+        showArmor: Boolean = true,
+        showCape: Boolean = true,
+        showHeldItem: Boolean = true,
+        showArrows: Boolean = true
     ) {
         val mouseX = -30f
         val mouseY = 0f

--- a/src/main/resources/ctjs_at.cfg
+++ b/src/main/resources/ctjs_at.cfg
@@ -12,3 +12,4 @@ public net.minecraft.command.CommandHandler field_71562_a           # commandMap
 public net.minecraft.nbt.NBTTagCompound field_74784_a               # tagMap
 public net.minecraft.client.gui.GuiScreenBook field_146483_y        # bookPages
 public net.minecraft.client.gui.GuiScreenBook field_146484_x        # currPage
+protected net.minecraft.client.renderer.entity.RenderPlayer func_177137_d(Lnet/minecraft/client/entity/AbstractClientPlayer;)V # setModelVisibilities


### PR DESCRIPTION
Added 5 more arguments to Renderer.drawPlayer method (showNametag, showArmor, showCape, showHeldItem, showArrows) and a (-1, 1, 1) scale so the user no longer needs to do negative scale to use it.
The arguments are pretty self explanatory. Performance shouldn't be bad, I did some testing (Thanks to DJtheRedstoner for some performance improvements).