### PR TITLE
Add toObject on NBTTagCompound

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/nbt/NBTTagCompound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/nbt/NBTTagCompound.kt
@@ -4,7 +4,7 @@ import com.chattriggers.ctjs.utils.kotlin.MCNBTBase
 import com.chattriggers.ctjs.utils.kotlin.MCNBTTagCompound
 import net.minecraft.nbt.NBTTagByteArray
 import net.minecraft.nbt.NBTTagIntArray
-import java.lang.IllegalArgumentException
+import org.mozilla.javascript.NativeObject
 
 class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
     val tagMap: Map<String, MCNBTBase>
@@ -99,5 +99,9 @@ class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
 
     fun removeTag(key: String) = apply {
         rawNBT.removeTag(key)
+    }
+
+    fun toObject(): NativeObject {
+        return rawNBT.toObject()
     }
 }


### PR DESCRIPTION
This allows for working with NBT more easily. For example:
```
eval> Player.getInventory().getStackInSlot(0).getNBT().toObject().id
minecraft:apple
eval> Player.getInventory().getStackInSlot(0).getNBT().toObject().Count
7
```