### PR TITLE
fixed blockBreak trigger

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
@@ -34,9 +34,7 @@ class CTJSTransformer : BaseClassTransformer() {
             injectRenderManager()
             injectEffectRenderer()
             injectGuiScreen()
-
-            // TODO: Investigate
-//            injectPlayerControllerMP()
+            injectPlayerControllerMP()
 
             ModuleManager.setup()
             ModuleManager.asmPass()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -225,7 +225,7 @@ object ClientListener {
         val event = CancellableEvent()
 
         TriggerType.HIT_BLOCK.triggerAll(
-            Block(World.getWorld()!!.getBlockState(pos).block),
+            World.getBlockAt(pos.x, pos.y, pos.z),
             BlockFace(facing),
             event
         )

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
@@ -143,15 +143,6 @@ object WorldListener {
     }
 
     @SubscribeEvent
-    fun blockBreak(event: BlockEvent.BreakEvent) {
-        TriggerType.BLOCK_BREAK.triggerAll(
-            World.getBlockAt(event.pos.x, event.pos.y, event.pos.z),
-            PlayerMP(event.player),
-            event
-        )
-    }
-
-    @SubscribeEvent
     fun livingDeathEvent(event: LivingDeathEvent) {
         TriggerType.ENTITY_DEATH.triggerAll(
             Entity(event.entity)


### PR DESCRIPTION
now injects instead of using the server side forge event

also hitBlock trigger now returns the correct block pos instead of always returning (0, 0, 0)

~~no idea why these triggers don't work in dev, but they're working in prod~~
edit: was an idiot and didn't read the contributing.md file

fixes #219