### PR TITLE
allow `print`, `Thread`, and `setTimeout` to be used in asm

### DIFF
--- a/src/main/resources/js/asmProvidedLibs.js
+++ b/src/main/resources/js/asmProvidedLibs.js
@@ -4,6 +4,9 @@ global.Java = {
     type: clazz => Packages[clazz]
 };
 
+global.Thread = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.threading.WrappedThread");
+global.Console = Java.type("com.chattriggers.ctjs.engine.langs.js.JSLoader").INSTANCE.getConsole();
+
 global.sync = (func, lock) => new org.mozilla.javascript.Synchronizer(func, lock);
 
 global.setTimeout = function (func, delay) {

--- a/src/main/resources/js/moduleProvidedLibs.js
+++ b/src/main/resources/js/moduleProvidedLibs.js
@@ -6,9 +6,6 @@ global.HashMap = Java.type("java.util.HashMap");
 global.Keyboard = Java.type("org.lwjgl.input.Keyboard");
 global.ReflectionHelper = Java.type("net.minecraftforge.fml.relauncher.ReflectionHelper");
 
-// Thread
-global.Thread = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.threading.WrappedThread");
-
 // Triggers
 global.TriggerRegister = Java.type("com.chattriggers.ctjs.engine.langs.js.JSRegister").INSTANCE;
 global.Priority = Java.type("com.chattriggers.ctjs.triggers.OnTrigger").Priority;
@@ -75,7 +72,6 @@ global.OnStepTrigger = Java.type("com.chattriggers.ctjs.triggers.OnStepTrigger")
 global.OnTrigger = Java.type("com.chattriggers.ctjs.triggers.OnTrigger");
 
 // Misc
-global.Console = Java.type("com.chattriggers.ctjs.engine.langs.js.JSLoader").INSTANCE.getConsole();
 global.Config = Java.type("com.chattriggers.ctjs.utils.config.Config").INSTANCE;
 global.ChatTriggers = Java.type("com.chattriggers.ctjs.Reference");
 /*End Built in Vars */


### PR DESCRIPTION
Previously, Console, & Thread weren't defined during the asm pass, so if a user tried calling either of them, it would throw an error.
This contradicted the ASM wiki page:


![image](https://user-images.githubusercontent.com/46137467/130337633-053af294-8021-4a69-87c6-9f4ec6cea5fd.png)
