### PR TITLE
ChatLib: Add addToSentMessageHistory

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleManager.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleManager.kt
@@ -27,9 +27,7 @@ object ModuleManager {
         ModuleUpdater.importPendingModules()
 
         // Get existing modules
-        val installedModules = getFoldersInDir(modulesFolder).map {
-            parseModule(it)
-        }.distinctBy {
+        val installedModules = getFoldersInDir(modulesFolder).map(::parseModule).distinctBy {
             it.name.lowercase()
         }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
@@ -58,7 +58,7 @@ object ChatLib {
      * Simulates a chat message to be caught by other triggers for testing.
      * The text can be a String, a [Message] or a [TextComponent]
      *
-     * @param message The message to simulate
+     * @param text The message to simulate
      */
     @JvmStatic
     fun simulateChat(text: Any) {
@@ -135,11 +135,7 @@ object ChatLib {
      */
     @JvmStatic
     fun getChatWidth(): Int {
-        return if (Client.getChatGUI() != null) {
-            Client.getChatGUI()!!.chatWidth
-        } else {
-            0
-        }
+        return Client.getChatGUI()?.chatWidth ?: 0
     }
 
     /**
@@ -324,6 +320,22 @@ object ChatLib {
         val hist = ChatListener.chatHistory.toMutableList()
         hist.reverse()
         return hist
+    }
+
+    /**
+     * Adds a message to the player's chat history. This allows the message to
+     * show up for the player when pressing the up/down keys while in the chat gui
+     *
+     * @param index the index to insert the message
+     * @param message the message to add to chat history
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun addToSentMessageHistory(index: Int = -1, message: String) {
+        val sentMessages = Client.getChatGUI()!!.sentMessages
+
+        if (index == -1) sentMessages.add(message)
+        else sentMessages.add(index, message)
     }
 
     /**

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -104,7 +104,7 @@ object Client {
     fun getKeyBindFromKey(keyCode: Int): KeyBind? {
         return getMinecraft().gameSettings.keyBindings
             .firstOrNull { it.keyCode == keyCode }
-            ?.let { KeyBind(it) }
+            ?.let(::KeyBind)
     }
 
     /**
@@ -135,7 +135,7 @@ object Client {
     fun getKeyBindFromDescription(description: String): KeyBind? {
         return getMinecraft().gameSettings.keyBindings
             .firstOrNull { it.keyDescription == description }
-            ?.let { KeyBind(it) }
+            ?.let(::KeyBind)
     }
 
     @JvmStatic

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
@@ -233,7 +233,7 @@ object Player {
     @JvmStatic
     fun getActivePotionEffects(): List<PotionEffect> {
         return getPlayer()?.activePotionEffects
-            ?.map { PotionEffect(it) }
+            ?.map(::PotionEffect)
             ?.toList()
             ?: listOf()
     }
@@ -282,7 +282,7 @@ object Player {
      * @return the player's inventory
      */
     @JvmStatic
-    fun getInventory(): Inventory? = getPlayer()?.let { Inventory(it.inventory) }
+    fun getInventory(): Inventory? = getPlayer()?.inventory?.let(::Inventory)
 
     /**
      * Gets the display name for the player,
@@ -318,7 +318,7 @@ object Player {
      * @return the currently opened inventory
      */
     @JvmStatic
-    fun getOpenedInventory(): Inventory? = getPlayer()?.openContainer?.let { Inventory(it) }
+    fun getOpenedInventory(): Inventory? = getPlayer()?.openContainer?.let(::Inventory)
 
     /**
      * Draws the player in the GUI

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
@@ -128,9 +128,7 @@ object Scoreboard {
 
             val scores: Collection<net.minecraft.scoreboard.Score> = scoreboard.getSortedScores(sidebarObjective)
 
-            scoreboardNames = scores.map {
-                Score(it)
-            }.toMutableList()
+            scoreboardNames = scores.map(::Score).toMutableList()
         } catch (ignored: Exception) {
         }
     }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
@@ -38,11 +38,9 @@ object TabList {
     fun getNames(): List<String> {
         if (Client.getTabGui() == null) return listOf()
 
-        val playerList = playerComparator.sortedCopy(Client.getMinecraft().thePlayer.sendQueue.playerInfoMap)
+        val playerList = playerComparator.sortedCopy(Player.getPlayer()!!.sendQueue.playerInfoMap)
 
-        return playerList.map {
-            Client.getTabGui()!!.getPlayerName(it)
-        }
+        return playerList.map(Client.getTabGui()!!::getPlayerName)
     }
 
     /**

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
@@ -145,9 +145,7 @@ object World {
      * @return the players
      */
     @JvmStatic
-    fun getAllPlayers(): List<PlayerMP> = getWorld()?.playerEntities?.map {
-        PlayerMP(it)
-    } ?: listOf()
+    fun getAllPlayers(): List<PlayerMP> = getWorld()?.playerEntities?.map(::PlayerMP) ?: listOf()
 
     /**
      * Gets a player by their username, must be in the currently loaded chunks!
@@ -174,9 +172,7 @@ object World {
 
     @JvmStatic
     fun getAllEntities(): List<Entity> {
-        return getWorld()?.loadedEntityList?.map {
-            Entity(it)
-        } ?: listOf()
+        return getWorld()?.loadedEntityList?.map(::Entity) ?: listOf()
     }
 
     /**

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/PlayerMP.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/PlayerMP.kt
@@ -19,9 +19,7 @@ class PlayerMP(val player: EntityPlayer) : Entity(player) {
     fun isSpectator() = this.player.isSpectator
 
     fun getActivePotionEffects(): List<PotionEffect> {
-        return player.activePotionEffects.map {
-            PotionEffect(it)
-        }
+        return player.activePotionEffects.map(::PotionEffect)
     }
 
     fun getPing(): Int {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Inventory.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Inventory.kt
@@ -74,7 +74,7 @@ class Inventory : JSONImpl {
      * @return a list of the [Item]s in an inventory
      */
     fun getItems(): List<Item> {
-        return (0 until getSize()).map { getStackInSlot(it) }
+        return (0 until getSize()).map(::getStackInSlot)
     }
 
     /**


### PR DESCRIPTION
Not sure if it should be called `addToChatHistory` or something like `addToSentMessages`. The only thing I can think of that makes it confusing is `ChatLib#getChatLines` retrieves `ChatListener.chatHistory`, which are the actual messages in chat, not the player's sent messages.

closes #254 