### PR TITLE
Add RenderSlotHighlight & PreItemRender triggers, Move Settings into Client, Change PostGuiRender param order

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -958,9 +958,9 @@ interface IRegister {
      * Registers a new trigger that runs after the current screen is rendered
      *
      * Passes through three arguments:
-     * - The GuiScreen
      * - The mouseX
      * - The mouseY
+     * - The GuiScreen
      *
      * Available modifications:
      * - [OnTrigger.setPriority] Sets the priority
@@ -970,6 +970,46 @@ interface IRegister {
      */
     fun registerPostGuiRender(method: Any): OnRegularTrigger {
         return OnRegularTrigger(method, TriggerType.PostGuiRender, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs before the items in the gui are drawn
+     *
+     * Passes through five arguments:
+     * - The mouseX position
+     * - The mouseY position
+     * - The Slot
+     * - The GuiContainer
+     *
+     * Available modifications:
+     * - [OnTrigger.setPriority] Sets the priority
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerPreItemRender(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.PreItemRender, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs before the hovered slot square is drawn.
+     *
+     * Passes through six arguments:
+     * - The mouseX position
+     * - The mouseY position
+     * - The Slot
+     * - The GuiContainer
+     * - The event, which can be cancelled
+     *
+     * Available modifications:
+     * - [OnRenderTrigger.triggerIfCanceled] Sets if triggered if event is already cancelled
+     * - [OnTrigger.setPriority] Sets the priority
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerRenderSlotHighlight(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.RenderSlotHighlight, getImplementationLoader())
     }
 
     /**

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSContextFactory.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSContextFactory.kt
@@ -46,7 +46,7 @@ object JSContextFactory : ContextFactory() {
         return super.hasFeature(cx, featureIndex)
     }
 
-    private class ModifiedURLClassLoader : URLClassLoader(arrayOf(), this::class.java.classLoader) {
+    private class ModifiedURLClassLoader : URLClassLoader(arrayOf(), javaClass.classLoader) {
         val sources = mutableListOf<URL>()
 
         fun addAllURLs(urls: List<URL>) {

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
@@ -35,6 +35,7 @@ class CTJSTransformer : BaseClassTransformer() {
             injectEffectRenderer()
             injectGuiScreen()
             injectPlayerControllerMP()
+            injectGuiContainer()
 
             ModuleManager.setup()
             ModuleManager.asmPass()

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
@@ -1,0 +1,101 @@
+package com.chattriggers.ctjs.launch.plugin
+
+import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.triggers.TriggerType
+import dev.falsehonesty.asmhelper.dsl.At
+import dev.falsehonesty.asmhelper.dsl.InjectionPoint
+import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.asm
+import dev.falsehonesty.asmhelper.dsl.inject
+import dev.falsehonesty.asmhelper.dsl.instructions.Descriptor
+import net.minecraft.client.gui.inventory.GuiContainer
+import net.minecraft.inventory.Slot
+
+fun injectGuiContainer() {
+    injectDrawForeground()
+    injectDrawSlotHighlight()
+}
+
+fun injectDrawForeground() = inject {
+    className = "net/minecraft/client/gui/inventory/GuiContainer"
+    methodName = "drawScreen"
+    methodDesc = "(IIF)V"
+
+    at = At(
+        InjectionPoint.INVOKE(
+            Descriptor(
+                "net/minecraft/client/gui/inventory/GuiContainer",
+                "drawGuiContainerForegroundLayer",
+                "(II)V"
+            )
+        ),
+        before = false
+    )
+
+    methodMaps = mapOf(
+        "func_148128_a" to "drawScreen",
+        "func_146979_b" to "drawGuiContainerForegroundLayer"
+    )
+
+    fieldMaps = mapOf("theSlot" to "field_147006_u")
+
+    codeBlock {
+        val theSlot = shadowField<Slot?>()
+
+        val local0 = shadowLocal<GuiContainer>()
+        val local1 = shadowLocal<Int>()
+        val local2 = shadowLocal<Int>()
+
+        code {
+            if (theSlot != null) {
+                TriggerType.PreItemRender.triggerAll(local1, local2, theSlot, local0)
+            }
+        }
+    }
+}
+
+fun injectDrawSlotHighlight() = inject {
+    className = "net/minecraft/client/gui/inventory/GuiContainer"
+    methodName = "drawScreen"
+    methodDesc = "(IIF)V"
+
+    at = At(
+        InjectionPoint.INVOKE(
+            Descriptor(
+                "net/minecraft/client/gui/inventory/GuiContainer",
+                "drawGradientRect",
+                "(IIIIII)V"
+            )
+        )
+    )
+
+    methodMaps = mapOf(
+        "func_148128_a" to "drawScreen",
+        "func_73733_a" to "drawGradientRect"
+    )
+
+    fieldMaps = mapOf("theSlot" to "field_147006_u")
+
+    codeBlock {
+        val theSlot = shadowField<Slot?>()
+
+        val local0 = shadowLocal<GuiContainer>()
+        val local1 = shadowLocal<Int>()
+        val local2 = shadowLocal<Int>()
+
+        code {
+            if (theSlot != null) {
+                val event = CancellableEvent()
+
+                TriggerType.RenderSlotHighlight.triggerAll(local1, local2, theSlot, local0, event)
+
+                if (event.isCancelled()) {
+                    asm {
+                        pop2()
+                        int(0)
+                        int(0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -147,7 +147,7 @@ object ClientListener {
 
     @SubscribeEvent
     fun onDrawScreenEvent(event: GuiScreenEvent.DrawScreenEvent.Post) {
-        TriggerType.PostGuiRender.triggerAll(event.gui, event.mouseX, event.mouseY)
+        TriggerType.PostGuiRender.triggerAll(event.mouseX, event.mouseY, event.gui)
     }
 
     @SubscribeEvent

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
@@ -19,7 +19,7 @@ import org.lwjgl.util.vector.Vector3f
 
 object WorldListener {
     private var shouldTriggerWorldLoad: Boolean = false
-    private var playerList: MutableList<String> = mutableListOf()
+    private var playerList = mutableListOf<String>()
 
     @SubscribeEvent
     fun onWorldLoad(event: WorldEvent.Load) {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/gui/Gui.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/gui/Gui.kt
@@ -39,11 +39,11 @@ abstract class Gui : GuiScreen() {
 
     fun isOpen(): Boolean = Client.getMinecraft().currentScreen === this
 
-    fun isControlDown(): Boolean = GuiScreen.isCtrlKeyDown()
+    fun isControlDown(): Boolean = isCtrlKeyDown()
 
-    fun isShiftDown(): Boolean = GuiScreen.isShiftKeyDown()
+    fun isShiftDown(): Boolean = isShiftKeyDown()
 
-    fun isAltDown(): Boolean = GuiScreen.isAltKeyDown()
+    fun isAltDown(): Boolean = isAltKeyDown()
 
     /**
      * Registers a method to be ran while gui is open.<br></br>

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/gui/GuiHandler.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/gui/GuiHandler.kt
@@ -1,14 +1,14 @@
 package com.chattriggers.ctjs.minecraft.objects.gui
 
+import com.chattriggers.ctjs.minecraft.wrappers.Client
 import com.chattriggers.ctjs.utils.kotlin.External
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 
 @External
 object GuiHandler {
-    private val GUIs: MutableMap<GuiScreen, Int> = mutableMapOf()
+    private val GUIs = mutableMapOf<GuiScreen, Int>()
 
     fun openGui(gui: GuiScreen) {
         GUIs[gui] = 1
@@ -25,7 +25,7 @@ object GuiHandler {
 
         GUIs.forEach {
             if (it.value == 0) {
-                Minecraft.getMinecraft().displayGuiScreen(it.key)
+                Client.getMinecraft().displayGuiScreen(it.key)
                 GUIs[it.key] = -1
             } else {
                 GUIs[it.key] = 0

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -18,7 +18,7 @@ import kotlin.math.roundToInt
 @External
 object Client {
     @JvmStatic
-    val settings = Settings
+    val settings = Settings()
 
     /**
      * Gets Minecraft's Minecraft object

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Scoreboard.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.minecraft.wrappers
 
 import com.chattriggers.ctjs.utils.kotlin.External
+import com.chattriggers.ctjs.utils.kotlin.MCScore
 import net.minecraft.scoreboard.ScorePlayerTeam
 import net.minecraftforge.client.GuiIngameForge
 
@@ -138,7 +139,7 @@ object Scoreboard {
         needsUpdate = true
     }
 
-    class Score(val score: net.minecraft.scoreboard.Score) {
+    class Score(val score: MCScore) {
         /**
          * Gets the score point value for this score,
          * i.e. the number on the right of the board

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Settings.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Settings.kt
@@ -7,79 +7,60 @@ import net.minecraft.entity.player.EnumPlayerModelParts
 import net.minecraft.world.EnumDifficulty
 
 @External
-object Settings {
-    @JvmStatic
+class Settings {
     fun getSettings() = Client.getMinecraft().gameSettings
 
-    @JvmStatic
     fun getFOV() = getSettings().fovSetting
 
-    @JvmStatic
     fun setFOV(fov: Float) {
         getSettings().fovSetting = fov
     }
 
-    @JvmStatic
     fun getDifficulty() = getSettings().difficulty.difficultyId
 
-    @JvmStatic
     fun setDifficulty(difficulty: Int) {
         getSettings().difficulty = EnumDifficulty.getDifficultyEnum(difficulty)
     }
 
-    object skin {
-        @JvmStatic
+    val skin = object {
         fun getCape() = getSettings().modelParts.contains(EnumPlayerModelParts.CAPE)
 
-        @JvmStatic
         fun setCape(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.CAPE)
         }
 
-        @JvmStatic
         fun getJacket() = getSettings().modelParts.contains(EnumPlayerModelParts.JACKET)
 
-        @JvmStatic
         fun setJacket(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.JACKET)
         }
 
-        @JvmStatic
         fun getLeftSleeve() = getSettings().modelParts.contains(EnumPlayerModelParts.LEFT_SLEEVE)
 
-        @JvmStatic
         fun setLeftSleeve(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.LEFT_SLEEVE)
         }
 
-        @JvmStatic
         fun getRightSleeve() = getSettings().modelParts.contains(EnumPlayerModelParts.RIGHT_SLEEVE)
 
-        @JvmStatic
         fun setRightSleeve(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.RIGHT_SLEEVE)
         }
 
-        @JvmStatic
         fun getLeftPantsLeg() = getSettings().modelParts.contains(EnumPlayerModelParts.LEFT_PANTS_LEG)
 
-        @JvmStatic
         fun setLeftPantsLeg(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.LEFT_PANTS_LEG)
         }
 
-        @JvmStatic
         fun getRightPantsLeg() = getSettings().modelParts.contains(EnumPlayerModelParts.RIGHT_PANTS_LEG)
 
-        @JvmStatic
         fun setRightPantsLeg(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.RIGHT_PANTS_LEG)
         }
 
-        @JvmStatic
         fun getHat() = getSettings().modelParts.contains(EnumPlayerModelParts.HAT)
 
-        @JvmStatic
         fun setHat(toggled: Boolean) {
             setModelPart(toggled, EnumPlayerModelParts.HAT)
         }
@@ -90,263 +71,218 @@ object Settings {
         }
     }
 
-    object sound {
-        @JvmStatic
+    val sound = object {
         fun getMasterVolume() = getSettings().getSoundLevel(MCSoundCategory.MASTER)
 
-        @JvmStatic
         fun setMasterVolume(level: Float) = getSettings().setSoundLevel(MCSoundCategory.MASTER, level)
 
-        @JvmStatic
         fun getMusicVolume() = getSettings().getSoundLevel(MCSoundCategory.MUSIC)
 
-        @JvmStatic
         fun setMusicVolume(level: Float) = getSettings().setSoundLevel(MCSoundCategory.MUSIC, level)
 
-        @JvmStatic
         fun getNoteblockVolume() = getSettings().getSoundLevel(MCSoundCategory.RECORDS)
 
-        @JvmStatic
         fun setNoteblockVolume(level: Float) = getSettings().setSoundLevel(MCSoundCategory.RECORDS, level)
 
-        @JvmStatic
         fun getWeather() = getSettings().getSoundLevel(MCSoundCategory.WEATHER)
 
-        @JvmStatic
         fun setWeather(level: Float) = getSettings().setSoundLevel(MCSoundCategory.WEATHER, level)
 
-        @JvmStatic
         fun getBlocks() = getSettings().getSoundLevel(MCSoundCategory.BLOCKS)
 
-        @JvmStatic
         fun setBlocks(level: Float) = getSettings().setSoundLevel(MCSoundCategory.BLOCKS, level)
 
         //#if MC<=10809
-        @JvmStatic
         fun getHostileCreatures() = getSettings().getSoundLevel(MCSoundCategory.MOBS)
 
-        @JvmStatic
         fun setHostileCreatures(level: Float) = getSettings().setSoundLevel(MCSoundCategory.MOBS, level)
 
-        @JvmStatic
         fun getFriendlyCreatures() = getSettings().getSoundLevel(MCSoundCategory.ANIMALS)
 
-        @JvmStatic
         fun setFriendlyCreatures(level: Float) = getSettings().setSoundLevel(MCSoundCategory.ANIMALS, level)
         //#else
-        //$$ @JvmStatic fun getHostileCreatures() = getSettings().getSoundLevel(SoundCategory.HOSTILE)
-        //$$ @JvmStatic fun setHostileCreatures(level: Float) = getSettings().setSoundLevel(SoundCategory.HOSTILE, level)
+        //$$ fun getHostileCreatures() = getSettings().getSoundLevel(MCSoundCategory.HOSTILE)
+        //$$ fun setHostileCreatures(level: Float) = getSettings().setSoundLevel(MCSoundCategory.HOSTILE, level)
         //$$
-        //$$ @JvmStatic fun getFriendlyCreatures() = getSettings().getSoundLevel(SoundCategory.NEUTRAL)
-        //$$ @JvmStatic fun setFriendlyCreatures(level: Float) = getSettings().setSoundLevel(SoundCategory.NEUTRAL, level)
+        //$$ fun getFriendlyCreatures() = getSettings().getSoundLevel(MCSoundCategory.NEUTRAL)
+        //$$ fun setFriendlyCreatures(level: Float) = getSettings().setSoundLevel(MCSoundCategory.NEUTRAL, level)
         //#endif
 
-        @JvmStatic
         fun getPlayers() = getSettings().getSoundLevel(MCSoundCategory.PLAYERS)
 
-        @JvmStatic
         fun setPlayers(level: Float) = getSettings().setSoundLevel(MCSoundCategory.PLAYERS, level)
 
-        @JvmStatic
         fun getAmbient() = getSettings().getSoundLevel(MCSoundCategory.AMBIENT)
 
-        @JvmStatic
         fun setAmbient(level: Float) = getSettings().setSoundLevel(MCSoundCategory.AMBIENT, level)
     }
 
-    object video {
-        @JvmStatic
+    val video = object {
         fun getGraphics() = getSettings().fancyGraphics
 
-        @JvmStatic
         fun setGraphics(fancy: Boolean) {
             getSettings().fancyGraphics = fancy
         }
 
-        @JvmStatic
         fun getRenderDistance() = getSettings().renderDistanceChunks
 
-        @JvmStatic
         fun setRenderDistance(distance: Int) {
             getSettings().renderDistanceChunks = distance
         }
 
-        @JvmStatic
         fun getSmoothLighting() = getSettings().ambientOcclusion
 
-        @JvmStatic
         fun setSmoothLighting(level: Int) {
             getSettings().ambientOcclusion = level
         }
 
-        @JvmStatic
         fun getMaxFrameRate() = getSettings().limitFramerate
 
-        @JvmStatic
         fun setMaxFrameRate(frameRate: Int) {
             getSettings().limitFramerate = frameRate
         }
 
-        @JvmStatic
         fun get3dAnaglyph() = getSettings().anaglyph
 
-        @JvmStatic
         fun set3dAnaglyph(toggled: Boolean) {
             getSettings().anaglyph = toggled
         }
 
-        @JvmStatic
         fun getBobbing() = getSettings().viewBobbing
 
-        @JvmStatic
         fun setBobbing(toggled: Boolean) {
             getSettings().viewBobbing = toggled
         }
 
-        @JvmStatic
         fun getGuiScale() = getSettings().guiScale
 
-        @JvmStatic
         fun setGuiScale(scale: Int) {
             getSettings().guiScale = scale
         }
 
-        @JvmStatic
         fun getBrightness() = getSettings().gammaSetting
 
-        @JvmStatic
         fun setBrightness(brightness: Float) {
             getSettings().gammaSetting = brightness
         }
 
-        @JvmStatic
         fun getClouds() = getSettings().clouds
 
-        @JvmStatic
         fun setClouds(clouds: Int) {
             getSettings().clouds = clouds
         }
 
-        @JvmStatic
         fun getParticles() = getSettings().particleSetting
 
-        @JvmStatic
         fun setParticles(particles: Int) {
             getSettings().particleSetting = particles
         }
 
-        @JvmStatic
         fun getFullscreen() = getSettings().fullScreen
 
-        @JvmStatic
         fun setFullscreen(toggled: Boolean) {
             getSettings().fullScreen = toggled
         }
 
-        @JvmStatic
         fun getVsync() = getSettings().enableVsync
 
-        @JvmStatic
         fun setVsync(toggled: Boolean) {
             getSettings().enableVsync = toggled
         }
 
-        @JvmStatic
         fun getMipmapLevels() = getSettings().mipmapLevels
 
-        @JvmStatic
         fun setMipmapLevels(mipmapLevels: Int) {
             getSettings().mipmapLevels = mipmapLevels
         }
 
         //#if MC<=10809
-        @JvmStatic
         fun getAlternateBlocks() = getSettings().allowBlockAlternatives
 
-        @JvmStatic
         fun setAlternateBlocks(toggled: Boolean) {
             getSettings().allowBlockAlternatives = toggled
         }
         //#else
-        //$$ @JvmStatic fun getAlternateBlocks() = UnsupportedOperationException("1.12 has no Alternative Blocks settings")
-        //$$ @JvmStatic fun setAlternateBlocks(toggled: Boolean) = UnsupportedOperationException("1.12 has no Alternative Blocks settings")
+        //$$ fun getAlternateBlocks() = UnsupportedOperationException("1.12 has no Alternative Blocks settings")
+        //$$ fun setAlternateBlocks(toggled: Boolean) = UnsupportedOperationException("1.12 has no Alternative Blocks settings")
         //#endif
 
-        @JvmStatic
         fun getVBOs() = getSettings().useVbo
 
-        @JvmStatic
         fun setVBOs(toggled: Boolean) {
             getSettings().useVbo = toggled
         }
 
-        @JvmStatic
         fun getEntityShadows() = getSettings().entityShadows
 
-        @JvmStatic
         fun setEntityShadows(toggled: Boolean) {
             getSettings().entityShadows = toggled
         }
     }
 
-    object chat {
-        // show chat
-        @JvmStatic
+    val chat = object {
         fun getVisibility() = getSettings().chatVisibility
 
-        @JvmStatic
         fun setVisibility(visibility: String) {
-            when (visibility.lowercase()) {
-                "hidden" -> getSettings().chatVisibility = EntityPlayer.EnumChatVisibility.HIDDEN
-                "commands", "system" -> getSettings().chatVisibility = EntityPlayer.EnumChatVisibility.SYSTEM
-                else -> getSettings().chatVisibility = EntityPlayer.EnumChatVisibility.FULL
+            getSettings().chatVisibility = when (visibility.lowercase()) {
+                "hidden" -> EntityPlayer.EnumChatVisibility.HIDDEN
+                "commands", "system" -> EntityPlayer.EnumChatVisibility.SYSTEM
+                else -> EntityPlayer.EnumChatVisibility.FULL
             }
         }
 
-        // colors
-        @JvmStatic
         fun getColors() = getSettings().chatColours
 
-        @JvmStatic
         fun setColors(toggled: Boolean) {
             getSettings().chatColours = toggled
         }
 
-        // web links
-        @JvmStatic
         fun getWebLinks() = getSettings().chatLinks
 
-        @JvmStatic
         fun setWebLinks(toggled: Boolean) {
             getSettings().chatLinks = toggled
         }
 
-        // opacity
-        @JvmStatic
         fun getOpacity() = getSettings().chatOpacity
 
-        @JvmStatic
         fun setOpacity(opacity: Float) {
             getSettings().chatOpacity = opacity
         }
 
-        // prompt on links
-        @JvmStatic
         fun getPromptOnWebLinks() = getSettings().chatLinksPrompt
 
-        @JvmStatic
         fun setPromptOnWebLinks(toggled: Boolean) {
             getSettings().chatLinksPrompt = toggled
         }
 
-        // scale
+        fun getScale() = getSettings().chatScale
 
-        // focused height
+        fun setScale(scale: Float) {
+            getSettings().chatScale = scale
+        }
 
-        // unfocused height
+        fun getFocusedHeight() = getSettings().chatHeightFocused
 
-        // width
+        fun setFocusedHeight(height: Float) {
+            getSettings().chatHeightFocused = height
+        }
 
-        // reduced debug info
+        fun getUnfocusedHeight() = getSettings().chatHeightUnfocused
+
+        fun setUnfocusedHeight(height: Float) {
+            getSettings().chatHeightUnfocused = height
+        }
+
+        fun getWidth() = getSettings().chatWidth
+
+        fun setWidth(width: Float) {
+            getSettings().chatWidth = width
+        }
+
+        fun getReducedDebugInfo() = getSettings().reducedDebugInfo
+
+        fun setReducedDebugInfo(toggled: Boolean) {
+            getSettings().reducedDebugInfo = toggled
+        }
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/TabList.kt
@@ -67,14 +67,24 @@ object TabList {
     @JvmStatic
     fun getHeader() = Client.getTabGui()?.header?.formattedText
 
+    /**
+     * Sets the header text for the TabList.
+     * If [header] is null, it will remove the header entirely
+     *
+     * @param header the header to set, or null to clear
+     */
     @JvmStatic
-    fun setHeader(header: Any) {
+    fun setHeader(header: Any?) {
         when (header) {
-            is String -> Client.getTabGui()?.setHeader(Message(header).getChatMessage())
-            is Message -> Client.getTabGui()?.setHeader(header.getChatMessage())
-            is MCITextComponent -> Client.getTabGui()?.setHeader(header)
+            is String -> Client.getTabGui()?.header = Message(header).getChatMessage()
+            is Message -> Client.getTabGui()?.header = header.getChatMessage()
+            is MCITextComponent -> Client.getTabGui()?.header = header
+            null -> Client.getTabGui()?.header = header
         }
     }
+
+    @JvmStatic
+    fun clearHeader() = setHeader(null)
 
     @JvmStatic
     fun getFooterMessage() = Client.getTabGui()?.footer?.let(::Message)
@@ -82,14 +92,24 @@ object TabList {
     @JvmStatic
     fun getFooter() = Client.getTabGui()?.footer?.formattedText
 
+    /**
+     * Sets the footer text for the TabList.
+     * If [footer] is null, it will remove the footer entirely
+     *
+     * @param footer the footer to set, or null to clear
+     */
     @JvmStatic
-    fun setFooter(footer: Any) {
+    fun setFooter(footer: Any?) {
         when (footer) {
-            is String -> Client.getTabGui()?.setFooter(Message(footer).getChatMessage())
-            is Message -> Client.getTabGui()?.setFooter(footer.getChatMessage())
-            is MCITextComponent -> Client.getTabGui()?.setFooter(footer)
+            is String -> Client.getTabGui()?.footer = Message(footer).getChatMessage()
+            is Message -> Client.getTabGui()?.footer = footer.getChatMessage()
+            is MCITextComponent -> Client.getTabGui()?.footer = footer
+            null -> Client.getTabGui()?.footer = footer
         }
     }
+
+    @JvmStatic
+    fun clearFooter() = setFooter(null)
 
     internal class PlayerComparator internal constructor() : Comparator<NetworkPlayerInfo> {
         override fun compare(playerOne: NetworkPlayerInfo, playerTwo: NetworkPlayerInfo): Int {

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/OnCommandTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/OnCommandTrigger.kt
@@ -7,7 +7,7 @@ import com.chattriggers.ctjs.utils.kotlin.External
 @External
 class OnCommandTrigger(method: Any, loader: ILoader) : OnTrigger(method, TriggerType.Command, loader) {
     private lateinit var commandName: String
-    private var tabCompletions: MutableList<String> = mutableListOf()
+    private var tabCompletions = mutableListOf<String>()
     private var command: Command? = null
 
     override fun trigger(args: Array<out Any?>) {

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -49,6 +49,8 @@ enum class TriggerType {
     RenderAir,
     RenderEntity,
     PostGuiRender,
+    PreItemRender,
+    RenderSlotHighlight,
 
     // world
     PlayerJoin,

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
@@ -7,6 +7,7 @@ internal typealias MCPotionEffect = net.minecraft.potion.PotionEffect
 internal typealias MCTessellator = net.minecraft.client.renderer.Tessellator
 internal typealias MCEnumFacing = net.minecraft.util.EnumFacing
 internal typealias MCBlock = net.minecraft.block.Block
+internal typealias MCScore = net.minecraft.scoreboard.Score
 
 //#if MC<=10809
 internal typealias MCParticle = net.minecraft.client.particle.EntityFX


### PR DESCRIPTION
- RenderSlotHighlight is fired whenever the mouse is hovering over a slot in the inventory and can cancel the white square from showing up.
- PreItemRender is a way to render after the gui background is drawn, but before the items are drawn. Here's an example of it in action: 
![image](https://user-images.githubusercontent.com/46137467/143271209-841f5b83-ac82-48ab-ba4b-2710ffb805aa.png)

- Moved Settings object into Client, this seems to be an issue with kotlin not liking triple nested objects being split up.  The issue can be seen [here](https://pl.kotl.in/L6tJfvid1)
