### PR TITLE
Added PostRenderEntity trigger and /ct reload shortcut to console

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -955,6 +955,24 @@ interface IRegister {
     }
 
     /**
+     * Registers a new trigger that runs after an entity is rendered
+     *
+     * Passes through three arguments:
+     * - The [com.chattriggers.ctjs.minecraft.wrappers.objects.Entity]
+     * - The position as a Vector3f
+     * - The partial ticks
+     *
+     * Available modifications:
+     * - [OnTrigger.setPriority] Sets the priority
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerPostRenderEntity(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.PostRenderEntity, getImplementationLoader())
+    }
+
+    /**
      * Registers a new trigger that runs after the current screen is rendered
      *
      * Passes through three arguments:

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/renderManager.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/renderManager.kt
@@ -10,7 +10,12 @@ import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.iReturn
 import dev.falsehonesty.asmhelper.dsl.inject
 import org.lwjgl.util.vector.Vector3f
 
-fun injectRenderManager() = inject {
+fun injectRenderManager() {
+    injectRenderEntity()
+    injectRenderEntityPost()
+}
+
+fun injectRenderEntity() = inject {
     className = "net/minecraft/client/renderer/entity/RenderManager"
     methodName = "doRenderEntity"
     methodDesc = "(L$ENTITY;DDDFFZ)Z"
@@ -36,6 +41,31 @@ fun injectRenderManager() = inject {
 
             if (event.isCancelled())
                 iReturn(0)
+        }
+    }
+}
+
+fun injectRenderEntityPost() = inject {
+    className = "net/minecraft/client/renderer/entity/RenderManager"
+    methodName = "doRenderEntity"
+    methodDesc = "(L$ENTITY;DDDFFZ)Z"
+    at = At(InjectionPoint.RETURN(2))
+
+    methodMaps = mapOf("func_147939_a" to "doRenderEntity")
+
+    codeBlock {
+        val local1 = shadowLocal<MCEntity>()
+        val local2 = shadowLocal<Double>()
+        val local4 = shadowLocal<Double>()
+        val local6 = shadowLocal<Double>()
+        val local9 = shadowLocal<Float>()
+
+        code {
+            TriggerType.PostRenderEntity.triggerAll(
+                Entity(local1),
+                Vector3f(local2.toFloat(), local4.toFloat(), local6.toFloat()),
+                local9
+            )
         }
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -51,6 +51,7 @@ enum class TriggerType {
     PostGuiRender,
     PreItemRender,
     RenderSlotHighlight,
+    PostRenderEntity,
 
     // world
     PlayerJoin,

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/console/Console.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/console/Console.kt
@@ -63,12 +63,24 @@ class Console(val loader: ILoader?) {
                         history.add(command)
                         historyOffset = 0
 
-                        taos.println("eval> ${command.prependIndent("    > ").substring(6)}")
+                        if (command == "help") {
+                            taos.println("""
+                                -------------- ChatTriggers Console Help --------------
+                                 Shortcuts:
+                                  Control + Enter: Run code in the textbox
+                                  Control + UP / DOWN: Cycle between ran code history
+                                  Control + L: Clear console
+                                  Control + R: Reload ChatTriggers
+                                -------------------------------------------------------
+                            """.trimIndent())
+                        } else {
+                            taos.println("eval> ${command.prependIndent("    > ").substring(6)}")
 
-                        try {
-                            taos.println(loader?.eval(command) ?: return)
-                        } catch (e: Throwable) {
-                            printStackTrace(e)
+                            try {
+                                taos.println(loader?.eval(command) ?: return)
+                            } catch (e: Throwable) {
+                                printStackTrace(e)
+                            }
                         }
                     }
 
@@ -99,6 +111,10 @@ class Console(val loader: ILoader?) {
 
                     KeyEvent.VK_L -> {
                         clearConsole()
+                    }
+
+                    KeyEvent.VK_R -> {
+                        Reference.loadCT()
                     }
                 }
             }


### PR DESCRIPTION
Added a postRenderEntity trigger so you can actually reset transformations done on renderEntity.
Added Control + R as a shortcut to JavaScript console to reload ChatTriggers.
Added 'help' keyword to console to print out all shortcuts.