### PR TITLE
Made GuiClosed trigger inject before closing.

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -564,7 +564,7 @@ interface IRegister {
      * Registers a new trigger that runs when a gui is closed.
      *
      * Passes through one argument:
-     * - The gui opened event
+     * - The gui that was closed
      *
      * Available modifications:
      * - [OnTrigger.setPriority] Sets the priority

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/minecraft.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/minecraft.kt
@@ -1,16 +1,23 @@
 package com.chattriggers.ctjs.launch.plugin
 
 import com.chattriggers.ctjs.minecraft.objects.message.TextComponent
+import com.chattriggers.ctjs.triggers.TriggerType
 import dev.falsehonesty.asmhelper.dsl.At
 import dev.falsehonesty.asmhelper.dsl.InjectionPoint
 import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.methodReturn
 import dev.falsehonesty.asmhelper.dsl.inject
 import dev.falsehonesty.asmhelper.dsl.instructions.Descriptor
+import net.minecraft.client.Minecraft
 import net.minecraft.client.shader.Framebuffer
 import net.minecraft.util.ScreenShotHelper
 import java.io.File
 
-fun injectMinecraft() = inject {
+fun injectMinecraft() {
+    injectDispatchKeypresses()
+    injectDisplayGuiScreen()
+}
+
+fun injectDispatchKeypresses() = inject {
     className = "net/minecraft/client/Minecraft"
     methodName = "dispatchKeypresses"
     methodDesc = "()V"
@@ -74,4 +81,31 @@ fun injectMinecraft() = inject {
 //
 //        methodReturn()
 //    }
+}
+
+fun injectDisplayGuiScreen() = inject {
+    className = "net/minecraft/client/Minecraft"
+    methodName = "displayGuiScreen"
+    methodDesc = "(Lnet/minecraft/client/gui/GuiScreen;)V"
+
+    at = At(
+        InjectionPoint.INVOKE(
+            Descriptor(
+                "net/minecraft/client/gui/GuiScreen",
+                "onGuiClosed",
+                "()V"
+            )
+        )
+    )
+
+    methodMaps = mapOf(
+        "func_147108_a" to "displayGuiScreen",
+        "onGuiClosed" to "func_146281_b"
+    )
+
+    codeBlock {
+        code {
+            TriggerType.GuiClosed.triggerAll(Minecraft.getMinecraft().currentScreen)
+        }
+    }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -192,8 +192,7 @@ object ClientListener {
 
     @SubscribeEvent
     fun onGuiOpened(event: GuiOpenEvent) {
-        if (event.gui == null) return TriggerType.GuiClosed.triggerAll(event)
-        TriggerType.GuiOpened.triggerAll(event)
+        if (event.gui != null) TriggerType.GuiOpened.triggerAll(event)
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This way you can actually see what GUI was closed. I left the null check in the guiOpened trigger because closing guis shouldn't trigger guiOpened. GuiClosed is NOT cancellable as it would break too many things.