### PR TITLE
MouseListener: Move process method into forge Mouse events

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
@@ -14,7 +14,8 @@ class Command(
     trigger: OnTrigger,
     private val name: String,
     private val usage: String,
-    private val tabCompletionOptions: MutableList<String>
+    private val tabCompletionOptions: MutableList<String>,
+    private var aliases: MutableList<String>,
 ) : CommandBase() {
     private var triggers = mutableListOf<OnTrigger>()
 
@@ -28,6 +29,12 @@ class Command(
     override fun getCommandName() = name
     //#else
     //$$ override fun getName() = name
+    //#endif
+
+    //#if MC<=10809
+    override fun getCommandAliases() = aliases
+    //#else
+    //$$ override fun getAliases() = aliases
     //#endif
 
     override fun getRequiredPermissionLevel() = 0
@@ -58,6 +65,10 @@ class Command(
     }
 
     fun register() {
+        if (name in ClientCommandHandler.instance.commandMap.keys) {
+            throw IllegalArgumentException("Command with name $name already exists!")
+        }
+
         ClientCommandHandler.instance.registerCommand(this)
         activeCommands[name] = this
     }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -128,6 +128,9 @@ object ClientListener {
     @SubscribeEvent
     fun onRenderTick(event: TickEvent.RenderTickEvent) {
         TriggerType.Step.triggerAll()
+        if (World.isLoaded()) {
+            MouseListener.handleDragged()
+        }
     }
 
     @SubscribeEvent
@@ -135,11 +138,6 @@ object ClientListener {
         GlStateManager.pushMatrix()
         handleOverlayTriggers(event)
         GlStateManager.popMatrix()
-
-        if (event.type != RenderGameOverlayEvent.ElementType.TEXT)
-            return
-
-        MouseListener.process()
     }
 
     private fun handleOverlayTriggers(event: RenderGameOverlayEvent.Pre) {


### PR DESCRIPTION
This solves the issues of clicked, scrolled, dragged triggers not firing when F1 is pressed, as well as the scroll trigger continuously triggering until another mouse input is detected.  I've played for a few hours now and I haven't had the fps drops from clicking, so I think that should also be fixed.