### PR TITLE
Added bunch of triggers for better keybind handling

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -794,6 +794,52 @@ interface IRegister {
     }
 
     /**
+     * Registers a new trigger that runs when a [KeyBind] is pressed
+     *
+     * Passes through two arguments:
+     * - The [KeyBind] that has been pressed
+     * - The keycode of the KeyBind
+     *
+     */
+    fun registerKeyBindPress(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.KeyBindPress, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs when a [KeyBind] is being held down
+     *
+     * Passes through two arguments:
+     * - The [KeyBind] that is held down
+     * - The keycode of the KeyBind
+     *
+     */
+    fun registerKeyBindDown(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.KeyBindDown, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs when a key is pressed
+     *
+     * Passes through one argument:
+     * - The keycode of the KeyBind
+     *
+     */
+    fun registerKeyPress(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.KeyPress, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs when a key is being held down
+     *
+     * Passes through one argument:
+     * - The keycode of the KeyBind
+     *
+     */
+    fun registerKeyDown(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.KeyDown, getImplementationLoader())
+    }
+
+    /**
      * Registers a new trigger that runs as a gui is rendered
      *
      * Passes through three arguments:

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -2,6 +2,8 @@ package com.chattriggers.ctjs.minecraft.listeners
 
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.libs.EventLib
+import com.chattriggers.ctjs.minecraft.objects.KeyBind
+import com.chattriggers.ctjs.minecraft.wrappers.Client
 import com.chattriggers.ctjs.minecraft.wrappers.Scoreboard
 import com.chattriggers.ctjs.minecraft.wrappers.World
 import com.chattriggers.ctjs.minecraft.wrappers.objects.block.BlockFace
@@ -23,8 +25,10 @@ import net.minecraftforge.event.entity.item.ItemTossEvent
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent
 import net.minecraftforge.event.entity.player.PlayerInteractEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.InputEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import net.minecraftforge.fml.common.network.FMLNetworkEvent
+import org.lwjgl.input.Keyboard
 import org.lwjgl.util.vector.Vector3f
 import org.mozilla.javascript.Context
 
@@ -73,6 +77,24 @@ object ClientListener {
         ticksPassed++
 
         Scoreboard.resetCache()
+
+        if (Keyboard.getEventKeyState() && Client.currentGui.get() == null) {
+            val key = Keyboard.getEventKey()
+            TriggerType.KeyDown.triggerAll(key)
+        }
+
+        KeyBind.ctKeyBinds.forEach {
+            if (it.isPressed()) TriggerType.KeyBindPress.triggerAll(it, it.getKeyCode())
+            else if (it.isKeyDown()) TriggerType.KeyBindDown.triggerAll(it, it.getKeyCode())
+        }
+    }
+
+    @SubscribeEvent
+    fun onKeyInput(event: InputEvent.KeyInputEvent) {
+        if (Keyboard.getEventKeyState()) {
+            val key = Keyboard.getEventKey()
+            TriggerType.KeyPress.triggerAll(key)
+        }
     }
 
     @SubscribeEvent

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/KeyBind.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/KeyBind.kt
@@ -37,6 +37,7 @@ class KeyBind {
             keyBinding = KeyBinding(description, keyCode, category)
             ClientRegistry.registerKeyBinding(keyBinding)
             keyBinds.add(keyBinding)
+            ctKeyBinds.add(this)
         }
     }
 
@@ -72,7 +73,27 @@ class KeyBind {
      */
     fun setState(pressed: Boolean) = KeyBinding.setKeyBindState(keyBinding.keyCode, pressed)
 
+    override fun equals(other: Any?): Boolean {
+        return if (other is KeyBind) {
+            other.keyBinding == keyBinding &&
+            other.keyBinding.keyCode == keyBinding.keyCode &&
+            other.keyBinding.keyCategory == keyBinding.keyCategory &&
+            other.keyBinding.keyDescription == keyBinding.keyDescription
+        } else false
+    }
+
+    override fun toString(): String {
+        return "KeyBind{description=${keyBinding.keyDescription}, " +
+            "keyCode=${keyBinding.keyCode}, " +
+            "category=${keyBinding.keyCategory}}"
+    }
+
+    override fun hashCode(): Int {
+        return keyBinding.hashCode()
+    }
+
     companion object {
         private val keyBinds = mutableListOf<KeyBinding>()
+        val ctKeyBinds = mutableListOf<KeyBind>()
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -35,6 +35,10 @@ enum class TriggerType {
     ServerDisconnect,
     GuiClosed,
     GuiDrawBackground,
+    KeyBindPress,
+    KeyBindDown,
+    KeyPress,
+    KeyDown,
 
     // rendering
     RenderWorld,


### PR DESCRIPTION
KeyPress and KeyDown will fire for ALL keys and they return the keycode of the pressed key.
KeyBindPress and KeyBindDown will fire only for ct KeyBinds. You have to use the newly added '.equals' method to compare the returned key with your KeyBind, or you can use the 2nd argument which is the keycode, again this is only for ct KeyBinds.

(note: none of these triggers will fire inside GUIs)

Example usage:
```js
let bind1 = new KeyBind("Bind 1", Keyboard.KEY_G);
let bind2 = new KeyBind("Bind 2", Keyboard.KEY_H);

register('keyBindPress', (key, keycode) => {
	print(keycode);
	if (key.equals(bind1)) print("Bind 1 has been pressed");
	else if (key.equals(bind2)) print("Bind 2 has been pressed");
});

register('keyBindDown', (key, keycode) => {
	print(keycode);
	if (key.equals(bind1)) print("Bind 1 is held down");
	else if (key.equals(bind2)) print("Bind 2 is held down");
});

register('keyPress', (keycode) => {
	print("Key Pressed: " + keycode);
});

register('keyDown', (keycode) => {
	print("Key Down: " + keycode);
});
```