### PR TITLE
Added option to override existing commands.

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
@@ -16,6 +16,7 @@ class Command(
     private val usage: String,
     private val tabCompletionOptions: MutableList<String>,
     private var aliases: MutableList<String>,
+    private val overrideExisting: Boolean = false
 ) : CommandBase() {
     private var triggers = mutableListOf<OnTrigger>()
 
@@ -65,7 +66,7 @@ class Command(
     }
 
     fun register() {
-        if (name in ClientCommandHandler.instance.commandMap.keys) {
+        if (name in ClientCommandHandler.instance.commandMap.keys && !overrideExisting) {
             throw IllegalArgumentException("Command with name $name already exists!")
         }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/OnCommandTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/OnCommandTrigger.kt
@@ -7,6 +7,7 @@ import com.chattriggers.ctjs.utils.kotlin.External
 @External
 class OnCommandTrigger(method: Any, loader: ILoader) : OnTrigger(method, TriggerType.Command, loader) {
     private lateinit var commandName: String
+    private var overrideExisting: Boolean = false
     private val tabCompletions = mutableListOf<String>()
     private val aliases = mutableListOf<String>()
     private var command: Command? = null
@@ -46,10 +47,13 @@ class OnCommandTrigger(method: Any, loader: ILoader) : OnTrigger(method, Trigger
      * would result in the command being /test
      *
      * @param commandName The command name
+     * @param overrideExisting Whether existing commands with the same name should be overridden
      * @return the trigger for additional modification
      */
-    fun setCommandName(commandName: String) = apply {
+    @JvmOverloads
+    fun setCommandName(commandName: String, overrideExisting: Boolean = false) = apply {
         this.commandName = commandName
+        this.overrideExisting = overrideExisting
         reInstance()
     }
 
@@ -57,13 +61,15 @@ class OnCommandTrigger(method: Any, loader: ILoader) : OnTrigger(method, Trigger
      * Alias for [setCommandName]
      *
      * @param commandName The command name
+     * @param overrideExisting Whether existing commands with the same name should be overridden
      * @return the trigger for additional modification
      */
-    fun setName(commandName: String) = setCommandName(commandName)
+    @JvmOverloads
+    fun setName(commandName: String, overrideExisting: Boolean = false) = setCommandName(commandName, overrideExisting)
 
     private fun reInstance() {
         command?.unregister()
-        command = Command(this, commandName, "/$commandName", tabCompletions, aliases)
+        command = Command(this, commandName, "/$commandName", tabCompletions, aliases, overrideExisting)
         command!!.register()
     }
 }


### PR DESCRIPTION
Before [this commit](https://github.com/ChatTriggers/ChatTriggers/commit/8868d78ef9551e460c3c3a928e5dd1ad6a73352b) commands were overridden by default. This change brings back the ability to override existing commands. The 2nd argument is optional, therefore it's not a breaking change.