### PR TITLE
Shape: Fix setLine not drawing & Text: Add support for \n

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Renderer.kt
@@ -127,7 +127,7 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun getRainbow(step: Float, speed: Float = 1f): Long {
-        val red = ((sin((step / speed).toDouble()) + 0.75) * 170).toLong()
+        val red = ((sin(step / speed) + 0.75) * 170).toLong()
         val green = ((sin(step / speed + 2 * PI / 3) + 0.75) * 170).toLong()
         val blue = ((sin(step / speed + 4 * PI / 3) + 0.75) * 170).toLong()
         return color(red, green, blue, 255)
@@ -136,7 +136,7 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun getRainbowColors(step: Float, speed: Float = 1f): IntArray {
-        val red = ((sin((step / speed).toDouble()) + 0.75) * 170).toInt()
+        val red = ((sin(step / speed) + 0.75) * 170).toInt()
         val green = ((sin(step / speed + 2 * PI / 3) + 0.75) * 170).toInt()
         val blue = ((sin(step / speed + 4 * PI / 3) + 0.75) * 170).toInt()
         return intArrayOf(red, green, blue)
@@ -251,9 +251,9 @@ object Renderer {
     @JvmStatic
     @JvmOverloads
     fun drawLine(color: Long, x1: Float, y1: Float, x2: Float, y2: Float, thickness: Float, drawMode: Int = 7) {
-        val theta = -atan2((y2 - y1).toDouble(), (x2 - x1).toDouble())
-        val i = sin(theta).toFloat() * (thickness / 2)
-        val j = cos(theta).toFloat() * (thickness / 2)
+        val theta = -atan2(y2 - y1, x2 - x1)
+        val i = sin(theta) * (thickness / 2)
+        val j = cos(theta) * (thickness / 2)
 
         GlStateManager.enableBlend()
         GlStateManager.disableTexture2D()
@@ -386,12 +386,12 @@ object Renderer {
         GlStateManager.rotate(180.0f, 0.0f, 0.0f, 1.0f)
         GlStateManager.rotate(45.0f, 0.0f, 1.0f, 0.0f)
         GlStateManager.rotate(-45.0f, 0.0f, 1.0f, 0.0f)
-        GlStateManager.rotate(-atan((mouseY / 40.0f).toDouble()).toFloat() * 20.0f, 1.0f, 0.0f, 0.0f)
+        GlStateManager.rotate(-atan(mouseY / 40.0f) * 20.0f, 1.0f, 0.0f, 0.0f)
         scale(-1f, 1f)
         if (!rotate) {
-            ent.renderYawOffset = atan((mouseX / 40.0f).toDouble()).toFloat() * 20.0f
-            ent.rotationYaw = atan((mouseX / 40.0f).toDouble()).toFloat() * 40.0f
-            ent.rotationPitch = -atan((mouseY / 40.0f).toDouble()).toFloat() * 20.0f
+            ent.renderYawOffset = atan(mouseX / 40.0f) * 20.0f
+            ent.rotationYaw = atan(mouseX / 40.0f) * 40.0f
+            ent.rotationPitch = -atan(mouseY / 40.0f) * 20.0f
             ent.rotationYawHead = ent.rotationYaw
             ent.prevRotationYawHead = ent.rotationYaw
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Shape.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Shape.kt
@@ -70,16 +70,15 @@ class Shape(private var color: Long) {
      */
     fun setLine(x1: Float, y1: Float, x2: Float, y2: Float, thickness: Float) = apply {
         vertexes.clear()
-        area = 0f
 
         val theta = -atan2(y2 - y1, x2 - x1)
         val i = sin(theta) * (thickness / 2)
         val j = cos(theta) * (thickness / 2)
 
-        vertexes.add(Vector2f(x1 + i, y1 + j))
-        vertexes.add(Vector2f(x2 + i, y2 + j))
-        vertexes.add(Vector2f(x2 - i, y2 - j))
-        vertexes.add(Vector2f(x1 - i, y1 - j))
+        addVertex(x1 + i, y1 + j)
+        addVertex(x2 + i, y2 + j)
+        addVertex(x2 - i, y2 - j)
+        addVertex(x1 - i, y1 - j)
 
         drawMode = 7
     }
@@ -90,7 +89,6 @@ class Shape(private var color: Long) {
      */
     fun setCircle(x: Float, y: Float, radius: Float, steps: Int) = apply {
         vertexes.clear()
-        area = 0f
 
         val theta = 2 * PI / steps
         val cos = cos(theta).toFloat()
@@ -101,12 +99,12 @@ class Shape(private var color: Long) {
         var circleY = 0f
 
         for (i in 0..steps) {
-            vertexes.add(Vector2f(x, y))
-            vertexes.add(Vector2f(circleX * radius + x, circleY * radius + y))
+            addVertex(x, y)
+            addVertex(circleX * radius + x, circleY * radius + y)
             xHolder = circleX
             circleX = cos * circleX - sin * circleY
             circleY = sin * xHolder + cos * circleY
-            vertexes.add(Vector2f(circleX * radius + x, circleY * radius + y))
+            addVertex(circleX * radius + x, circleY * radius + y)
         }
 
         drawMode = 5

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
@@ -16,7 +16,7 @@ class Text @JvmOverloads constructor(private var string: String, private var x: 
 
     private var width = 0f
     private var maxWidth = 0
-    private var maxLines = 1
+    private var maxLines = Int.MAX_VALUE
     private var scale = 1f
 
     init {
@@ -133,10 +133,12 @@ class Text @JvmOverloads constructor(private var string: String, private var x: 
 
         lines.clear()
 
-        if (maxWidth > 0) {
-            lines.addAll(Renderer.getFontRenderer().listFormattedStringToWidth(string, maxWidth))
-        } else {
-            lines.add(string)
+        string.split("\n").forEach {
+            if (maxWidth > 0) {
+                lines.addAll(Renderer.getFontRenderer().listFormattedStringToWidth(it, maxWidth))
+            } else {
+                lines.add(it)
+            }
         }
     }
 
@@ -152,7 +154,7 @@ class Text @JvmOverloads constructor(private var string: String, private var x: 
     override fun toString() =
         "Text{" +
                 "string=$string, x=$x, y=$y, " +
-                "lines=$lines, color=$color, scale=$scale" +
+                "lines=$lines, color=$color, scale=$scale, " +
                 "formatted=$formatted, shadow=$shadow, align=$align, " +
                 "width=$width, maxWidth=$maxWidth, maxLines=$maxLines" +
                 "}"

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayLine.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayLine.kt
@@ -19,10 +19,10 @@ abstract class DisplayLine {
 
     private var textWidth = 0f
 
-    internal var textColor: Long? = null
-    internal var backgroundColor: Long? = null
-    internal var background: DisplayHandler.Background? = null
-    internal var align: DisplayHandler.Align? = null
+    private var textColor: Long? = null
+    private var backgroundColor: Long? = null
+    private var background: DisplayHandler.Background? = null
+    private var align: DisplayHandler.Align? = null
 
     private var onClicked: OnTrigger? = null
     private var onHovered: OnTrigger? = null


### PR DESCRIPTION
This was due to the area being equal to 0, so in the draw method, it would use the reversed vertices, causing nothing to be drawn.