### PR TITLE
Client: Fix nested objects being undefined

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
@@ -8,6 +8,8 @@ import com.chattriggers.ctjs.minecraft.objects.gui.Gui
 import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBind
 import com.chattriggers.ctjs.minecraft.wrappers.Client
 import net.minecraft.client.settings.KeyBinding
+import net.minecraft.network.INetHandler
+import net.minecraft.network.Packet
 import org.mozilla.javascript.NativeObject
 
 /*
@@ -45,6 +47,7 @@ class JSKeyBind : KeyBind {
     @JvmOverloads
     constructor(category: String, key: Int, description: String = "ChatTriggers") : super(category, key, description)
     constructor(keyBinding: KeyBinding) : super(keyBinding)
+
     override fun getLoader(): ILoader = JSLoader
 }
 
@@ -71,4 +74,34 @@ object JSClient : Client() {
             .firstOrNull { it.keyDescription == description }
             ?.let(::JSKeyBind)
     }
+
+    val settings = Client.settings
+    fun getMinecraft() = Client.getMinecraft()
+    fun getConnection() = Client.getConnection()
+    fun disconnect() = Client.disconnect()
+    fun getChatGUI() = Client.getChatGUI()
+    fun isInChat() = Client.isInChat()
+    fun getTabGui() = Client.getTabGui()
+    fun isInTab() = Client.isInTab()
+    fun isTabbedIn() = Client.isTabbedIn()
+    fun isControlDown() = Client.isControlDown()
+    fun isShiftDown() = Client.isShiftDown()
+    fun isAltDown() = Client.isAltDown()
+    fun getFPS() = Client.getFPS()
+    fun getVersion() = Client.getVersion()
+    fun getMaxMemory() = Client.getMaxMemory()
+    fun getTotalMemory() = Client.getTotalMemory()
+    fun getFreeMemory() = Client.getFreeMemory()
+    fun getMemoryUsage() = Client.getMemoryUsage()
+    fun getSystemTime() = Client.getSystemTime()
+    fun getMouseX() = Client.getMouseX()
+    fun getMouseY() = Client.getMouseY()
+    fun isInGui() = Client.isInGui()
+    fun getCurrentChatMessage() = Client.getCurrentChatMessage()
+    fun setCurrentChatMessage(message: String) = Client.setCurrentChatMessage(message)
+    fun <T : INetHandler> sendPacket(packet: Packet<T>) = Client.sendPacket(packet)
+    fun showTitle(title: String, subtitle: String, fadeIn: Int, time: Int, fadeOut: Int) =
+        Client.showTitle(title, subtitle, fadeIn, time, fadeOut)
+    val currentGui = Client.Companion.currentGui
+    val camera = Client.Companion.camera
 }


### PR DESCRIPTION
This fixes the massive issue I accidentally created in 835b681338e56ba38702e2a4e062107f81f29add.  When inheriting classes, Kotlin doesn't inherit the nested objects inside, so this is the best workaround I could find. 