### PR TITLE
Fix pressing media keys triggering all keybinds

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
@@ -75,33 +75,6 @@ object JSClient : Client() {
             ?.let(::JSKeyBind)
     }
 
-    val settings = Client.settings
-    fun getMinecraft() = Client.getMinecraft()
-    fun getConnection() = Client.getConnection()
-    fun disconnect() = Client.disconnect()
-    fun getChatGUI() = Client.getChatGUI()
-    fun isInChat() = Client.isInChat()
-    fun getTabGui() = Client.getTabGui()
-    fun isInTab() = Client.isInTab()
-    fun isTabbedIn() = Client.isTabbedIn()
-    fun isControlDown() = Client.isControlDown()
-    fun isShiftDown() = Client.isShiftDown()
-    fun isAltDown() = Client.isAltDown()
-    fun getFPS() = Client.getFPS()
-    fun getVersion() = Client.getVersion()
-    fun getMaxMemory() = Client.getMaxMemory()
-    fun getTotalMemory() = Client.getTotalMemory()
-    fun getFreeMemory() = Client.getFreeMemory()
-    fun getMemoryUsage() = Client.getMemoryUsage()
-    fun getSystemTime() = Client.getSystemTime()
-    fun getMouseX() = Client.getMouseX()
-    fun getMouseY() = Client.getMouseY()
-    fun isInGui() = Client.isInGui()
-    fun getCurrentChatMessage() = Client.getCurrentChatMessage()
-    fun setCurrentChatMessage(message: String) = Client.setCurrentChatMessage(message)
-    fun <T : INetHandler> sendPacket(packet: Packet<T>) = Client.sendPacket(packet)
-    fun showTitle(title: String, subtitle: String, fadeIn: Int, time: Int, fadeOut: Int) =
-        Client.showTitle(title, subtitle, fadeIn, time, fadeOut)
     val currentGui = Client.Companion.currentGui
     val camera = Client.Companion.camera
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiScreen.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiScreen.kt
@@ -203,10 +203,12 @@ fun injectTextComponentClick() = inject {
         val local1 = shadowLocal<MCITextComponent?>()
 
         code {
-            val event = CancellableEvent()
-            TriggerType.ChatComponentClicked.triggerAll(local1?.let(::TextComponent), event)
-            if (event.isCancelled())
-                iReturn(0)
+            if (local1 != null) {
+                val event = CancellableEvent()
+                TriggerType.ChatComponentClicked.triggerAll(TextComponent(local1), event)
+                if (event.isCancelled())
+                    iReturn(0)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBindHandler.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBindHandler.kt
@@ -26,9 +26,4 @@ internal object KeyBindHandler {
 
         keyBinds.forEach(KeyBind::onTick)
     }
-
-    @SubscribeEvent
-    fun onKeyInput(event: InputEvent.KeyInputEvent) {
-        keyBinds.forEach(KeyBind::onKeyInput)
-    }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/OnChatTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/OnChatTrigger.kt
@@ -12,7 +12,7 @@ class OnChatTrigger(method: Any, type: TriggerType, loader: ILoader) : OnTrigger
     private var formatted: Boolean = false
     private var caseInsensitive: Boolean = false
     private lateinit var criteriaPattern: Regex
-    private var parameters = mutableListOf<Parameter?>()
+    private val parameters = mutableListOf<Parameter?>()
     private var triggerIfCanceled: Boolean = true
 
     /**
@@ -38,7 +38,7 @@ class OnChatTrigger(method: Any, type: TriggerType, loader: ILoader) : OnTrigger
 
         when (chatCriteria) {
             is String -> {
-                formatted = "&" in chatCriteria
+                formatted = Regex("[&\u00a7]") in chatCriteria
 
                 val replacedCriteria = Regex.escape(chatCriteria.replace("\n", "->newLine<-"))
                     .replace(Regex("\\\$\\{[^*]+?}"), "\\\\E(.+)\\\\Q")
@@ -61,7 +61,7 @@ class OnChatTrigger(method: Any, type: TriggerType, loader: ILoader) : OnTrigger
                     if ("" == it) ".+" else it
                 }
 
-                formatted = "&" in source
+                formatted = Regex("[&\u00a7]") in source
             }
             else -> throw IllegalArgumentException("Expected String or Regexp Object")
         }
@@ -83,7 +83,8 @@ class OnChatTrigger(method: Any, type: TriggerType, loader: ILoader) : OnTrigger
      * @return the trigger object for method chaining
      */
     fun setParameter(parameter: String) = apply {
-        parameters = mutableListOf(Parameter.getParameterByName(parameter))
+        parameters.clear()
+        addParameter(parameter)
     }
 
     /**


### PR DESCRIPTION
There was an issue with all KeyBinds using registerKeyPress triggering at the same time when the user pressed media keys (e.g. fn + F1 for mute)
closes #296 

- Removed unneeded Client calls, inheritance already allows for this.
- Made ChatComponentClicked trigger only trigger when clicking on ChatComponents (this is how ChatComponentHovered works)
- Allow § to count as formatted, so users can set criteria with it.