### PR TITLE
WorldListener: Make GameLoad trigger on Game Load

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/WorldListener.kt
@@ -24,6 +24,8 @@ object WorldListener {
 
     @SubscribeEvent
     fun onWorldLoad(event: WorldEvent.Load) {
+        if (!shouldTriggerWorldLoad)
+            TriggerType.GameLoad.triggerAll()
         playerList.clear()
         shouldTriggerWorldLoad = true
     }


### PR DESCRIPTION
Previously it would only trigger on /ct load