### PR TITLE
Add draw slot trigger

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -2,6 +2,7 @@ package com.chattriggers.ctjs.engine
 
 import com.chattriggers.ctjs.minecraft.listeners.ClientListener
 import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Item
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.triggers.*
 import com.chattriggers.ctjs.utils.kotlin.External
 import kotlin.reflect.KFunction
@@ -871,8 +872,8 @@ interface IRegister {
      * This is useful for hiding "background" items in containers used as GUIs.
      *
      * Passes through three arguments:
-     * - The MC Slot being drawn
-     * - The [GUIScreen] that is being drawn
+     * - The [Slot] being drawn
+     * - The MC GUIScreen that is being drawn
      * - The event, which can be cancelled
      */
 
@@ -1191,7 +1192,7 @@ interface IRegister {
      * Passes through five arguments:
      * - The mouseX position
      * - The mouseY position
-     * - The Slot
+     * - The MC Slot
      * - The GuiContainer
      *
      * Available modifications:
@@ -1210,7 +1211,7 @@ interface IRegister {
      * Passes through six arguments:
      * - The mouseX position
      * - The mouseY position
-     * - The Slot
+     * - The MC Slot
      * - The GuiContainer
      * - The event, which can be cancelled
      *

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -867,6 +867,19 @@ interface IRegister {
     }
 
     /**
+     * Registers a new trigger that runs before a slot is drawn in a container
+     * This is useful for hiding "background" items in containers used as GUIs.
+     *
+     * Passes through three arguments:
+     * - The MC Slot being drawn
+     * - The [GUIScreen] that is being drawn
+     * - The event, which can be cancelled
+     */
+
+    fun registerDrawSlot(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.DrawSlot, getImplementationLoader())
+    }
+    /**
      * Registers a new trigger that runs before the gui background is drawn
      * This is useful for drawing custom backgrounds.
      *

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
@@ -5,6 +5,7 @@ import com.chattriggers.ctjs.triggers.TriggerType
 import dev.falsehonesty.asmhelper.dsl.At
 import dev.falsehonesty.asmhelper.dsl.InjectionPoint
 import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.asm
+import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.methodReturn
 import dev.falsehonesty.asmhelper.dsl.inject
 import dev.falsehonesty.asmhelper.dsl.instructions.Descriptor
 import net.minecraft.client.gui.inventory.GuiContainer
@@ -14,6 +15,39 @@ import net.minecraft.inventory.Slot
 fun injectGuiContainer() {
     injectDrawForeground()
     injectDrawSlotHighlight()
+    injectDrawSlot()
+}
+
+fun injectDrawSlot() = inject {
+    className = "net/minecraft/client/gui/inventory/GuiContainer"
+    methodName = "drawSlot"
+    methodDesc = "(Lnet/minecraft/inventory/Slot;)V"
+
+    at = At(InjectionPoint.HEAD)
+
+    methodMaps = mapOf(
+            "func_146977_a" to "drawSlot",
+    )
+
+    fieldMaps = mapOf("theSlot" to "field_147006_u")
+
+    codeBlock {
+
+        val local0 = shadowLocal<GuiContainer>()
+        val local1 = shadowLocal<Slot>()
+
+        code {
+            val event = CancellableEvent()
+
+            GlStateManager.pushMatrix()
+            TriggerType.DrawSlot.triggerAll(local1, local0, event)
+            GlStateManager.popMatrix()
+
+            if (event.isCancelled()) {
+                methodReturn()
+            }
+        }
+    }
 }
 
 fun injectDrawForeground() = inject {

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
@@ -1,7 +1,9 @@
 package com.chattriggers.ctjs.launch.plugin
 
 import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.triggers.TriggerType
+import com.chattriggers.ctjs.utils.kotlin.MCSlot
 import dev.falsehonesty.asmhelper.dsl.At
 import dev.falsehonesty.asmhelper.dsl.InjectionPoint
 import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.asm
@@ -10,7 +12,6 @@ import dev.falsehonesty.asmhelper.dsl.inject
 import dev.falsehonesty.asmhelper.dsl.instructions.Descriptor
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
-import net.minecraft.inventory.Slot
 
 fun injectGuiContainer() {
     injectDrawForeground()
@@ -34,13 +35,13 @@ fun injectDrawSlot() = inject {
     codeBlock {
 
         val local0 = shadowLocal<GuiContainer>()
-        val local1 = shadowLocal<Slot>()
+        val local1 = shadowLocal<MCSlot>()
 
         code {
             val event = CancellableEvent()
 
             GlStateManager.pushMatrix()
-            TriggerType.DrawSlot.triggerAll(local1, local0, event)
+            TriggerType.DrawSlot.triggerAll(Slot(local1), local0, event)
             GlStateManager.popMatrix()
 
             if (event.isCancelled()) {
@@ -74,7 +75,7 @@ fun injectDrawForeground() = inject {
     fieldMaps = mapOf("theSlot" to "field_147006_u")
 
     codeBlock {
-        val theSlot = shadowField<Slot?>()
+        val theSlot = shadowField<MCSlot?>()
 
         val local0 = shadowLocal<GuiContainer>()
         val local1 = shadowLocal<Int>()
@@ -113,7 +114,7 @@ fun injectDrawSlotHighlight() = inject {
     fieldMaps = mapOf("theSlot" to "field_147006_u")
 
     codeBlock {
-        val theSlot = shadowField<Slot?>()
+        val theSlot = shadowField<MCSlot?>()
 
         val local0 = shadowLocal<GuiContainer>()
         val local1 = shadowLocal<Int>()

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -1,11 +1,13 @@
 package com.chattriggers.ctjs.minecraft.wrappers
 
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
 import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBind
 import com.chattriggers.ctjs.utils.kotlin.External
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.*
+import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.multiplayer.WorldClient
 import net.minecraft.client.network.NetHandlerPlayClient
 import net.minecraft.network.INetHandler
@@ -232,6 +234,19 @@ abstract class Client {
              */
             @JvmStatic
             fun get(): GuiScreen? = getMinecraft().currentScreen
+
+            /**
+             * Gets the slot under the mouse in the current gui, if one exists.
+             *
+             * @return the [Slot] under the mouse
+             */
+            @JvmStatic
+            fun getSlotUnderMouse(): Slot? {
+                val screen: GuiScreen? = get()
+                return if ((screen is GuiContainer) && (screen.slotUnderMouse != null)) {
+                    Slot(screen.slotUnderMouse)
+                } else null
+            }
 
             /**
              * Closes the currently open gui

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Slot.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Slot.kt
@@ -1,0 +1,21 @@
+package com.chattriggers.ctjs.minecraft.wrappers.objects.inventory
+
+import com.chattriggers.ctjs.utils.kotlin.External
+import com.chattriggers.ctjs.utils.kotlin.MCSlot
+import net.minecraft.client.gui.inventory.GuiContainer
+
+@External
+class Slot(val mcSlot: MCSlot) {
+
+    fun getIndex(): Int = mcSlot.slotNumber
+
+    fun getDisplayX(): Int = mcSlot.xDisplayPosition
+
+    fun getDisplayY(): Int = mcSlot.yDisplayPosition
+
+    fun getInventory(): Inventory = Inventory(mcSlot.inventory)
+
+    fun getItem(): Item? = if (mcSlot.stack != null) Item(mcSlot.stack) else null
+
+    override fun toString(): String = "Slot ${getIndex()} of (${getInventory().getClassName()}: ${getInventory().getName()}): ${getItem()}"
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -34,6 +34,7 @@ enum class TriggerType {
     ServerConnect,
     ServerDisconnect,
     GuiClosed,
+    DrawSlot,
     GuiDrawBackground,
 
     // rendering

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
@@ -11,6 +11,7 @@ internal typealias MCScore = net.minecraft.scoreboard.Score
 internal typealias MCTileEntity = net.minecraft.tileentity.TileEntity
 internal typealias MCScoreboard = net.minecraft.scoreboard.Scoreboard
 internal typealias MCItem = net.minecraft.item.Item
+internal typealias MCSlot = net.minecraft.inventory.Slot
 
 //#if MC<=10809
 internal typealias MCParticle = net.minecraft.client.particle.EntityFX


### PR DESCRIPTION
Hi – this adds a trigger that runs as slots in containers are being drawn, allowing item rendering to be cancelled within containers (e.g. for removing background items in containers used as GUIs or visually replacing an item). First pull request to anything so apologies if this is very wrong.