### PR TITLE
Add additional item drawing features

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Item.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Item.kt
@@ -245,6 +245,7 @@ class Item {
      * @param scale the scale
      * @param z the z level to draw the item at
      */
+    @JvmOverloads
     fun drawWithOverlay(x: Float = 0f, y: Float = 0f, scale: Float = 1f, z: Float = 200f) {
         val stackSize = this.getStackSize()
         var overlayText: String? = null
@@ -255,7 +256,7 @@ class Item {
         }
 
         var durability: Float? = if (this.isDamagable()) (this.getDamage().toFloat() / this.getMaxDamage()) else null
-        if (durability == 1f) durability = null
+        if (durability == 0f) durability = null
         this.draw(x, y, scale, z, overlayText, durability)
     }
 


### PR DESCRIPTION
- Adds drawWithOverlay() method for rendering items with their stack size and damage, as in vanilla (basically emulating renderItemOverlayInGui)
- Adds optional arguments for z-level, custom overlay text (e.g. stack size), and custom "durability bar" in draw().
- Change setStackSize() to not remove damage / other ItemStack data (may break modules that relied on this, but seems unlikely anyone would rely on this).