### PR TITLE
Item rendering triggers

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -2,6 +2,7 @@ package com.chattriggers.ctjs.engine
 
 import com.chattriggers.ctjs.minecraft.listeners.ClientListener
 import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Item
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.triggers.*
 import com.chattriggers.ctjs.utils.kotlin.External
 import kotlin.reflect.KFunction
@@ -1196,7 +1197,7 @@ interface IRegister {
      * Passes through five arguments:
      * - The mouseX position
      * - The mouseY position
-     * - The Slot
+     * - The MC Slot
      * - The GuiContainer
      *
      * Available modifications:
@@ -1210,12 +1211,60 @@ interface IRegister {
     }
 
     /**
+     * Registers a new trigger that runs before a slot is drawn in a container
+     * This is useful for hiding "background" items in containers used as GUIs.
+     *
+     * Passes through three arguments:
+     * - The [Slot] being drawn
+     * - The MC GUIScreen that is being drawn
+     * - The event, which can be cancelled
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerRenderSlot(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.RenderSlot, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs before each item is drawn into a GUI.
+     *
+     * Passes through four arguments:
+     * - The [Item]
+     * - The x position
+     * - The y position
+     * - The event, which can be cancelled.
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerRenderItemIntoGui(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.RenderItemIntoGui, getImplementationLoader())
+    }
+
+    /**
+     * Registers a new trigger that runs before each item overlay (stack size and damage bar) is drawn.
+     *
+     * Passes through four arguments:
+     * - The [Item]
+     * - The x position
+     * - The y position
+     * - The event, which can be cancelled.
+     *
+     * @param method The method to call when the event is fired
+     * @return The trigger for additional modification
+     */
+    fun registerRenderItemOverlayIntoGui(method: Any): OnRegularTrigger {
+        return OnRegularTrigger(method, TriggerType.RenderItemOverlayIntoGui, getImplementationLoader())
+    }
+
+    /**
      * Registers a new trigger that runs before the hovered slot square is drawn.
      *
      * Passes through six arguments:
      * - The mouseX position
      * - The mouseY position
-     * - The Slot
+     * - The MC Slot
      * - The GuiContainer
      * - The event, which can be cancelled
      *

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
@@ -38,7 +38,7 @@ class CTJSTransformer : BaseClassTransformer() {
             injectTileEntityRendererDispatcher()
             injectGuiIngame()
             injectGuiIngameForge()
-
+            injectRenderItem()
             ModuleManager.setup()
             ModuleManager.asmPass()
         } catch (e: Throwable) {

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt
@@ -1,19 +1,54 @@
 package com.chattriggers.ctjs.launch.plugin
 
 import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Item
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.triggers.TriggerType
+import com.chattriggers.ctjs.utils.kotlin.MCSlot
 import dev.falsehonesty.asmhelper.dsl.At
 import dev.falsehonesty.asmhelper.dsl.InjectionPoint
 import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.asm
+import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.methodReturn
 import dev.falsehonesty.asmhelper.dsl.inject
 import dev.falsehonesty.asmhelper.dsl.instructions.Descriptor
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
-import net.minecraft.inventory.Slot
+import net.minecraft.item.ItemStack
 
 fun injectGuiContainer() {
+    injectDrawSlot()
     injectDrawForeground()
     injectDrawSlotHighlight()
+}
+
+fun injectDrawSlot() = inject {
+    className = "net/minecraft/client/gui/inventory/GuiContainer"
+    methodName = "drawSlot"
+    methodDesc = "(Lnet/minecraft/inventory/Slot;)V"
+
+    at = At(InjectionPoint.HEAD)
+
+    methodMaps = mapOf(
+        "func_146977_a" to "drawSlot",
+    )
+
+    codeBlock {
+
+        val local0 = shadowLocal<GuiContainer>()
+        val local1 = shadowLocal<MCSlot>()
+
+        code {
+            val event = CancellableEvent()
+
+            GlStateManager.pushMatrix()
+            TriggerType.RenderSlot.triggerAll(Slot(local1), local0, event)
+            GlStateManager.popMatrix()
+
+            if (event.isCancelled()) {
+                methodReturn()
+            }
+        }
+    }
 }
 
 fun injectDrawForeground() = inject {
@@ -40,7 +75,7 @@ fun injectDrawForeground() = inject {
     fieldMaps = mapOf("theSlot" to "field_147006_u")
 
     codeBlock {
-        val theSlot = shadowField<Slot?>()
+        val theSlot = shadowField<MCSlot?>()
 
         val local0 = shadowLocal<GuiContainer>()
         val local1 = shadowLocal<Int>()
@@ -79,7 +114,7 @@ fun injectDrawSlotHighlight() = inject {
     fieldMaps = mapOf("theSlot" to "field_147006_u")
 
     codeBlock {
-        val theSlot = shadowField<Slot?>()
+        val theSlot = shadowField<MCSlot?>()
 
         val local0 = shadowLocal<GuiContainer>()
         val local1 = shadowLocal<Int>()

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiIngame.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiIngame.kt
@@ -1,11 +1,13 @@
 package com.chattriggers.ctjs.launch.plugin
 
 import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.minecraft.wrappers.Player
 import com.chattriggers.ctjs.triggers.TriggerType
 import dev.falsehonesty.asmhelper.dsl.At
 import dev.falsehonesty.asmhelper.dsl.InjectionPoint
 import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.methodReturn
 import dev.falsehonesty.asmhelper.dsl.inject
+import net.minecraft.client.renderer.GlStateManager
 
 fun injectGuiIngame() {
     injectRenderScoreboard()
@@ -29,3 +31,4 @@ fun injectRenderScoreboard() = inject {
         }
     }
 }
+

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/renderItem.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/renderItem.kt
@@ -1,0 +1,72 @@
+package com.chattriggers.ctjs.launch.plugin
+
+import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Item
+import com.chattriggers.ctjs.triggers.TriggerType
+import dev.falsehonesty.asmhelper.dsl.At
+import dev.falsehonesty.asmhelper.dsl.InjectionPoint
+import dev.falsehonesty.asmhelper.dsl.code.CodeBlock.Companion.methodReturn
+import dev.falsehonesty.asmhelper.dsl.inject
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.item.ItemStack
+
+fun injectRenderItem() {
+    injectRenderItemAndEffectIntoGUI()
+    injectRenderItemOverlayIntoGUI()
+}
+
+fun injectRenderItemAndEffectIntoGUI() = inject {
+    className = "net/minecraft/client/renderer/entity/RenderItem"
+    methodName = "renderItemAndEffectIntoGUI"
+    methodDesc = "(Lnet/minecraft/item/ItemStack;II)V"
+    at = At(InjectionPoint.HEAD)
+
+    methodMaps = mapOf("func_180450_b" to "renderItemAndEffectIntoGUI")
+
+    codeBlock {
+        val local1 = shadowLocal<ItemStack?>()
+        val local2 = shadowLocal<Int>()
+        val local3 = shadowLocal<Int>()
+
+        code {
+            if (local1 != null) {
+                val event = CancellableEvent()
+
+                GlStateManager.pushMatrix()
+                TriggerType.RenderItemIntoGui.triggerAll(Item(local1), local2, local3, event)
+                GlStateManager.popMatrix()
+
+                if (event.isCanceled())
+                    methodReturn()
+            }
+        }
+    }
+}
+
+fun injectRenderItemOverlayIntoGUI() = inject {
+    className = "net/minecraft/client/renderer/entity/RenderItem"
+    methodName = "renderItemOverlayIntoGUI"
+    methodDesc = "(Lnet/minecraft/client/gui/FontRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V"
+    at = At(InjectionPoint.HEAD)
+
+    methodMaps = mapOf("func_180453_a" to "renderItemOverlayIntoGUI")
+
+    codeBlock {
+        val local2 = shadowLocal<ItemStack?>()
+        val local3 = shadowLocal<Int>()
+        val local4 = shadowLocal<Int>()
+
+        code {
+            if (local2 != null) {
+                val event = CancellableEvent()
+
+                GlStateManager.pushMatrix()
+                TriggerType.RenderItemOverlayIntoGui.triggerAll(Item(local2), local3, local4, event)
+                GlStateManager.popMatrix()
+
+                if (event.isCanceled())
+                    methodReturn()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -1,11 +1,13 @@
 package com.chattriggers.ctjs.minecraft.wrappers
 
+import com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
 import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBind
 import com.chattriggers.ctjs.utils.kotlin.External
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.*
+import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.multiplayer.WorldClient
 import net.minecraft.client.network.NetHandlerPlayClient
 import net.minecraft.network.INetHandler
@@ -232,6 +234,19 @@ abstract class Client {
              */
             @JvmStatic
             fun get(): GuiScreen? = getMinecraft().currentScreen
+
+            /**
+             * Gets the slot under the mouse in the current gui, if one exists.
+             *
+             * @return the [Slot] under the mouse
+             */
+            @JvmStatic
+            fun getSlotUnderMouse(): Slot? {
+                val screen: GuiScreen? = get()
+                return if ((screen is GuiContainer) && (screen.slotUnderMouse != null)) {
+                    Slot(screen.slotUnderMouse)
+                } else null
+            }
 
             /**
              * Closes the currently open gui

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Item.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Item.kt
@@ -15,6 +15,9 @@ import net.minecraft.enchantment.Enchantment
 import net.minecraft.enchantment.EnchantmentHelper
 import net.minecraft.entity.item.EntityItem
 import net.minecraft.item.ItemStack
+import net.minecraft.util.EnumChatFormatting
+import kotlin.math.round
+import kotlin.math.roundToLong
 
 //#if MC>10809
 //$$ import net.minecraft.client.util.ITooltipFlag
@@ -88,7 +91,7 @@ class Item {
     fun getID(): Int = MCItem.getIdFromItem(item)
 
     fun setStackSize(stackSize: Int) = apply {
-        itemStack = ItemStack(item, stackSize)
+        itemStack.stackSize = stackSize
     }
 
     fun getStackSize(): Int {
@@ -188,14 +191,15 @@ class Item {
     }
 
     /**
-     * Renders the item icon to the client's overlay.
+     * Renders the item icon to the client's overlay, with customizable overlay information.
      *
      * @param x the x location
      * @param y the y location
      * @param scale the scale
+     * @param z the z level to draw the item at
      */
     @JvmOverloads
-    fun draw(x: Float = 0f, y: Float = 0f, scale: Float = 1f) {
+    fun draw(x: Float = 0f, y: Float = 0f, scale: Float = 1f, z: Float = 200f) {
         val itemRenderer = Client.getMinecraft().renderItem
 
         GlStateManager.scale(scale, scale, 1f)
@@ -205,7 +209,7 @@ class Item {
         RenderHelper.enableStandardItemLighting()
         RenderHelper.enableGUIStandardItemLighting()
 
-        itemRenderer.zLevel = 200f
+        itemRenderer.zLevel = z
         itemRenderer.renderItemIntoGUI(itemStack, 0, 0)
 
         Renderer.finishDraw()
@@ -233,3 +237,4 @@ class Item {
 
     override fun toString(): String = itemStack.toString()
 }
+

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Slot.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/objects/inventory/Slot.kt
@@ -1,0 +1,19 @@
+package com.chattriggers.ctjs.minecraft.wrappers.objects.inventory
+
+import com.chattriggers.ctjs.utils.kotlin.External
+import com.chattriggers.ctjs.utils.kotlin.MCSlot
+
+@External
+class Slot(val mcSlot: MCSlot) {
+    fun getIndex(): Int = mcSlot.slotNumber
+
+    fun getDisplayX(): Int = mcSlot.xDisplayPosition
+
+    fun getDisplayY(): Int = mcSlot.yDisplayPosition
+
+    fun getInventory(): Inventory = Inventory(mcSlot.inventory)
+
+    fun getItem(): Item? = if (mcSlot.stack != null) Item(mcSlot.stack) else null
+
+    override fun toString(): String = "Slot ${getIndex()} of (${getInventory().getClassName()}: ${getInventory().getName()}): ${getItem()}"
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/TriggerType.kt
@@ -34,6 +34,7 @@ enum class TriggerType {
     ServerConnect,
     ServerDisconnect,
     GuiClosed,
+    RenderSlot,
     GuiDrawBackground,
 
     // rendering
@@ -60,6 +61,8 @@ enum class TriggerType {
     RenderEntity,
     PostGuiRender,
     PreItemRender,
+    RenderItemIntoGui,
+    RenderItemOverlayIntoGui,
     RenderSlotHighlight,
     PostRenderEntity,
     RenderTileEntity,

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/TypeAliases.kt
@@ -11,6 +11,7 @@ internal typealias MCScore = net.minecraft.scoreboard.Score
 internal typealias MCTileEntity = net.minecraft.tileentity.TileEntity
 internal typealias MCScoreboard = net.minecraft.scoreboard.Scoreboard
 internal typealias MCItem = net.minecraft.item.Item
+internal typealias MCSlot = net.minecraft.inventory.Slot
 
 //#if MC<=10809
 internal typealias MCParticle = net.minecraft.client.particle.EntityFX

--- a/src/main/resources/js/moduleProvidedLibs.js
+++ b/src/main/resources/js/moduleProvidedLibs.js
@@ -60,6 +60,7 @@ global.PlayerMP = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.en
 
 global.Inventory = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Inventory");
 global.Item = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Item");
+global.Slot = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.Slot");
 
 global.Action = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.action.Action");
 global.ClickAction = Java.type("com.chattriggers.ctjs.minecraft.wrappers.objects.inventory.action.ClickAction");


### PR DESCRIPTION
Some new triggers and utilities around rendering items and slots:
- renderSlot(Slot, gui, event) triggers when a slot is being drawn
- renderItemIntoGui(Item, x, y, event) triggers for each item being drawn into a gui (doesn't trigger on Item.draw)
- renderItemOverlayIntoGui(Item, x, y, event) triggers for each item overlay being drawn into a GUI.
- Simple slot wrapper
- Client.currentGui.getSlotUnderMouse() method.
- Add z-level optional argument to Item.draw(x, y, scale, z) for positioning.

(the renderItemIntoGui and renderItemOverlayIntoGui duplication is a bit inelegant, but I don't think there's many times where you would actually want to cancel both and an impractical number of methods call those two)
