### PR TITLE
Add colors to console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ minecraft {
         11202: '1.12.2-14.23.0.2486',
         11201: '1.12.1-14.22.0.2444',
         11200: '1.12-14.21.1.2387',
-        10809: '1.8.9-11.15.1.1722'
+        10809: '1.8.9-11.15.1.2318-1.8.9'
     ][mcVersion]
     mappings = [
         11202: "snapshot_20170615",
@@ -79,12 +79,12 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.spongepowered.org/repository/maven-public/' }
     maven { url 'https://jitpack.io' }
-    maven { url "https://repo.sk1er.club/repository/maven-public" }
+    maven { url "https://repo.essential.gg/repository/maven-public" }
 }
 
 dependencies {
     provided "gg.essential:loader-launchwrapper:1.1.3"
-    implementation "gg.essential:essential-1.8.9-forge:1788"
+    implementation "gg.essential:essential-1.8.9-forge:2487"
 
     provided("dev.falsehonesty.asmhelper:AsmHelper:1.5.3-$mcVersion") {
         exclude group: "org.jetbrains.kotlin"

--- a/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
@@ -13,6 +13,7 @@ import com.chattriggers.ctjs.minecraft.wrappers.World
 import com.chattriggers.ctjs.triggers.TriggerType
 import com.chattriggers.ctjs.utils.Config
 import com.chattriggers.ctjs.utils.console.Console
+import com.chattriggers.ctjs.utils.console.LogType
 import com.chattriggers.ctjs.utils.kotlin.External
 import com.chattriggers.ctjs.utils.kotlin.times
 import com.google.common.reflect.ClassPath
@@ -129,5 +130,7 @@ object Reference {
     }
 }
 
-fun Any.printToConsole(console: Console = ModuleManager.generalConsole) = console.println(this)
+fun Any.printToConsole(console: Console = ModuleManager.generalConsole, logType: LogType = LogType.INFO) {
+    console.println(this, logType)
+}
 fun Throwable.printTraceToConsole(console: Console = ModuleManager.generalConsole) = console.printStackTrace(this)

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
@@ -9,6 +9,7 @@ import com.chattriggers.ctjs.printTraceToConsole
 import com.chattriggers.ctjs.triggers.OnTrigger
 import com.chattriggers.ctjs.triggers.TriggerType
 import com.chattriggers.ctjs.utils.console.Console
+import com.chattriggers.ctjs.utils.console.LogType
 import dev.falsehonesty.asmhelper.dsl.*
 import dev.falsehonesty.asmhelper.dsl.instructions.InsnListBuilder
 import dev.falsehonesty.asmhelper.dsl.writers.AccessType
@@ -114,7 +115,7 @@ object JSLoader : ILoader {
 
             if (asmFunction == null) {
                 "Asm entry for module ${module.name} has an invalid export. " +
-                        "An Asm entry must have a default export of a function.".printToConsole(console)
+                        "An Asm entry must have a default export of a function.".printToConsole(console, LogType.WARN)
                 return@wrapInContext
             }
 
@@ -124,7 +125,7 @@ object JSLoader : ILoader {
             println("Error loading asm entry for module ${module.name}")
             e.printStackTrace()
             e.printTraceToConsole(console)
-            "Error loading asm entry for module ${module.name}".printToConsole(console)
+            "Error loading asm entry for module ${module.name}".printToConsole(console, LogType.ERROR)
         }
     }
 
@@ -155,7 +156,7 @@ object JSLoader : ILoader {
             println("Error loading module ${module.name}")
             e.printStackTrace()
 
-            "Error loading module ${module.name}".printToConsole(console)
+            "Error loading module ${module.name}".printToConsole(console, LogType.ERROR)
             e.printTraceToConsole(console)
         }
     }
@@ -173,7 +174,10 @@ object JSLoader : ILoader {
                 println("Error loading asm function $functionURI in module ${module.name}.")
                 e.printStackTrace()
 
-                "Error loading asm function $functionURI in module ${module.name}.".printToConsole(console)
+                "Error loading asm function $functionURI in module ${module.name}.".printToConsole(
+                    console,
+                    LogType.ERROR,
+                )
                 e.printTraceToConsole(console)
 
                 // If we can't resolve the target function correctly, we will return
@@ -224,7 +228,7 @@ object JSLoader : ILoader {
         _methodDesc: String,
         _fieldMaps: Map<String, String>,
         _methodMaps: Map<String, String>,
-        _insnList: (Wrapper) -> Unit
+        _insnList: (Wrapper) -> Unit,
     ) {
         inject {
             className = _className
@@ -249,7 +253,7 @@ object JSLoader : ILoader {
         _methodName: String,
         _methodDesc: String,
         _methodMaps: Map<String, String>,
-        _numberToRemove: Int
+        _numberToRemove: Int,
     ) {
         remove {
             className = _className
@@ -267,7 +271,7 @@ object JSLoader : ILoader {
         _fieldName: String,
         _fieldDesc: String,
         _initialValue: Any?,
-        _accessTypes: List<AccessType>
+        _accessTypes: List<AccessType>,
     ) {
         applyField {
             className = _className

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleUpdater.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleUpdater.kt
@@ -8,6 +8,7 @@ import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.printToConsole
 import com.chattriggers.ctjs.printTraceToConsole
 import com.chattriggers.ctjs.utils.Config
+import com.chattriggers.ctjs.utils.console.LogType
 import com.chattriggers.ctjs.utils.kotlin.toVersion
 import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.event.world.WorldEvent
@@ -78,7 +79,7 @@ object ModuleUpdater {
 
             if (newMetadata.version == null) {
                 ("Remote version of module ${metadata.name} has no version numbers, so it will " +
-                        "not be updated!").printToConsole()
+                        "not be updated!").printToConsole(logType = LogType.WARN)
                 return
             } else if (metadata.version != null && metadata.version.toVersion() >= newMetadata.version.toVersion()) {
                 return
@@ -95,7 +96,7 @@ object ModuleUpdater {
                 tryReportChangelog(module.metadata)
             }
         } catch (e: Exception) {
-            "Can't find page for ${metadata.name}".printToConsole()
+            "Can't find page for ${metadata.name}".printToConsole(logType = LogType.WARN)
         }
     }
 

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
@@ -122,4 +122,37 @@ object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sorting
         category = "Console",
     )
     var consoleBackgroundColor = Color(21, 21, 21)
+
+    @Property(
+        PropertyType.SWITCH,
+        name = "Use custom console colors for errors or warnings",
+        category = "Console",
+    )
+    var consoleErrorAndWarningColors = false
+
+    @Property(
+        PropertyType.COLOR,
+        name = "Console error color",
+        category = "Console",
+    )
+    var consoleErrorColor = Color(225, 65, 73)
+
+    @Property(
+        PropertyType.COLOR,
+        name = "Console warning color",
+        category = "Console",
+    )
+    var consoleWarningColor = Color(248, 191, 84)
+
+    init {
+        addDependency(
+            javaClass.getDeclaredField("consoleErrorColor"),
+            javaClass.getDeclaredField("consoleErrorAndWarningColors"),
+        )
+
+        addDependency(
+            javaClass.getDeclaredField("consoleWarningColor"),
+            javaClass.getDeclaredField("consoleErrorAndWarningColors"),
+        )
+    }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/console/LogType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/console/LogType.kt
@@ -1,0 +1,7 @@
+package com.chattriggers.ctjs.utils.console
+
+enum class LogType {
+    INFO,
+    WARN,
+    ERROR,
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/console/TextAreaWriter.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/console/TextAreaWriter.kt
@@ -1,16 +1,40 @@
 package com.chattriggers.ctjs.utils.console
 
+import com.chattriggers.ctjs.utils.Config
+import java.awt.Color
 import java.io.PrintWriter
 import java.io.Writer
-import javax.swing.JTextArea
+import javax.swing.JTextPane
+import javax.swing.text.AttributeSet
+import javax.swing.text.SimpleAttributeSet
+import javax.swing.text.StyleConstants
+import javax.swing.text.StyleContext
 
-class TextAreaWriter(private val textArea: JTextArea) : Writer() {
+class TextAreaWriter(private val textArea: JTextPane) : Writer() {
     val printWriter = PrintWriter(this)
+    private var currentLogType: LogType = LogType.INFO
+    private var customColor: Color? = null
 
     override fun write(cbuf: CharArray, off: Int, len: Int) {
         val s = String(cbuf, off, len)
-        textArea.append(s)
+        val sc: StyleContext = StyleContext.getDefaultStyleContext()
+
+        val color = customColor ?: when (currentLogType) {
+            LogType.INFO -> Config.consoleForegroundColor
+            LogType.WARN -> Config.consoleWarningColor
+            LogType.ERROR -> Config.consoleErrorColor
+        }
+
+        val attributes: AttributeSet = sc.addAttribute(
+            SimpleAttributeSet.EMPTY,
+            StyleConstants.Foreground,
+            color,
+        )
+
+        textArea.document.insertString(textArea.document.length, s, attributes)
         textArea.caretPosition = textArea.document.length
+        currentLogType = LogType.INFO
+        customColor = null
     }
 
     override fun flush() {
@@ -21,7 +45,14 @@ class TextAreaWriter(private val textArea: JTextArea) : Writer() {
 
     }
 
-    fun println(s: Any) = printWriter.println(s)
+    @JvmOverloads
+    fun println(s: Any, logType: LogType = LogType.INFO, customColor: Color? = null) {
+        if (Config.consoleErrorAndWarningColors) {
+            currentLogType = logType
+            this.customColor = customColor
+        }
+        printWriter.println(s)
+    }
 
     fun clear() {
         textArea.text = ""

--- a/src/main/resources/js/asmProvidedLibs.js
+++ b/src/main/resources/js/asmProvidedLibs.js
@@ -16,15 +16,17 @@ global.setTimeout = function (func, delay) {
     }).start();
 };
 
+const LogType = com.chattriggers.ctjs.utils.console.LogType;
+
 // simplified methods
-global.print = function (toPrint) {
+global.print = function (toPrint, color = null) {
     if (toPrint === null) {
         toPrint = 'null';
     } else if (toPrint === undefined) {
         toPrint = 'undefined';
     }
 
-    Console.println(toPrint);
+    Console.println(toPrint, LogType.INFO, color);
 };
 
 /**
@@ -185,12 +187,12 @@ global.print = function (toPrint) {
 
 
     // Printer
-    _.println = function (s) {
-        Console.println(s);
+    _.printlnWarn = function (s) {
+        Console.println(s, LogType.WARN);
     };
 
     _.printLineToStdErr = function (s) {
-        Console.println(s);
+        Console.println(s, LogType.ERROR);
     };
 
     _.printLineToStdOut = function (s) {
@@ -218,9 +220,12 @@ global.print = function (toPrint) {
             : "");
         switch (msgType) {
             case "assert":
-            case "error":
+            case "error": {
+                this.printLineToStdErr(prefix + indent + msg);
+                break;
+            }
             case "warn": {
-                _.printLineToStdErr(prefix + indent + msg);
+                _.printlnWarn(prefix + indent + msg);
                 break;
             }
             default: {


### PR DESCRIPTION
This adds the option for colors in the console via `console.log`, `console.warn`, `console.error`, and `console.assert`.  Also added an option to `print` to take in a second argument allowing for custom colors.  I didn't add that to `console.log` or its other methods since they already take varargs, making it impossible to tell if the user wanted to print the color in string form, or wanted to color the text.