### PR TITLE
Text: Add constructor taking a NativeObject

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Text.kt
@@ -3,10 +3,16 @@ package com.chattriggers.ctjs.minecraft.libs.renderer
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.objects.display.DisplayHandler
 import com.chattriggers.ctjs.utils.kotlin.External
+import com.chattriggers.ctjs.utils.kotlin.getOption
 import net.minecraft.client.renderer.GlStateManager
+import org.mozilla.javascript.NativeObject
 
 @External
-class Text @JvmOverloads constructor(private var string: String, private var x: Float = 0f, private var y: Float = 0f) {
+class Text {
+    private lateinit var string: String
+    private var x: Float = 0f
+    private var y: Float = 0f
+
     private val lines = mutableListOf<String>()
 
     private var color = 0xffffffff
@@ -19,8 +25,24 @@ class Text @JvmOverloads constructor(private var string: String, private var x: 
     private var maxLines = Int.MAX_VALUE
     private var scale = 1f
 
-    init {
-        updateFormatting()
+    @JvmOverloads
+    constructor(string: String, x: Float = 0f, y: Float = 0f) {
+        setString(string)
+        setX(x)
+        setY(y)
+    }
+
+    constructor(string: String, config: NativeObject) {
+        setString(string)
+        setColor(config.getOption("color", 0xffffffff).toLong())
+        setFormatted(config.getOption("formatted", true).toBoolean())
+        setShadow(config.getOption("shadow", false).toBoolean())
+        setAlign(config.getOption("align", DisplayHandler.Align.LEFT))
+        setX(config.getOption("x", 0f).toFloat())
+        setY(config.getOption("y", 0f).toFloat())
+        setMaxLines((config.getOption("maxLines", Int.MAX_VALUE)).toDouble().toInt())
+        setScale(config.getOption("scale", 1f).toFloat())
+        setMaxWidth(config.getOption("maxWidth", 0).toInt())
     }
 
     fun getString(): String = string

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/Display.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/Display.kt
@@ -2,12 +2,13 @@ package com.chattriggers.ctjs.minecraft.objects.display
 
 import com.chattriggers.ctjs.utils.kotlin.External
 import com.chattriggers.ctjs.utils.kotlin.NotAbstract
+import com.chattriggers.ctjs.utils.kotlin.getOption
 import org.mozilla.javascript.NativeObject
 import java.util.concurrent.CopyOnWriteArrayList
 
 @External
 @NotAbstract
-abstract class Display {
+abstract class Display() {
     private var lines = CopyOnWriteArrayList<DisplayLine>()
 
     private var renderX = 0f
@@ -26,32 +27,22 @@ abstract class Display {
 
     internal var registerType = DisplayHandler.RegisterType.RENDER_OVERLAY
 
-    constructor() {
+    init {
         @Suppress("LeakingThis")
         DisplayHandler.registerDisplay(this)
     }
 
-    constructor(config: NativeObject?) {
-        shouldRender = config.getOption("shouldRender", true).toBoolean()
-        renderX = config.getOption("renderX", 0).toFloat()
-        renderY = config.getOption("renderY", 0).toFloat()
-
+    constructor(config: NativeObject?) : this() {
         setBackgroundColor(config.getOption("backgroundColor", 0x50000000).toLong())
-        setBackground(config.getOption("background", DisplayHandler.Background.NONE))
         setTextColor(config.getOption("textColor", 0xffffffff).toLong())
+        setBackground(config.getOption("background", DisplayHandler.Background.NONE))
         setAlign(config.getOption("align", DisplayHandler.Align.LEFT))
         setOrder(config.getOption("order", DisplayHandler.Order.DOWN))
-
-        minWidth = config.getOption("minWidth", 0f).toFloat()
-
+        setRenderX(config.getOption("renderX", 0f).toFloat())
+        setRenderY(config.getOption("renderY", 0f).toFloat())
+        setShouldRender(config.getOption("shouldRender", true).toBoolean())
+        setMinWidth(config.getOption("minWidth", 0f).toFloat())
         setRegisterType(config.getOption("registerType", DisplayHandler.RegisterType.RENDER_OVERLAY))
-
-        @Suppress("LeakingThis")
-        DisplayHandler.registerDisplay(this)
-    }
-
-    private fun NativeObject?.getOption(key: String, default: Any): String {
-        return (this?.get(key) ?: default).toString()
     }
 
     fun getBackgroundColor(): Long = backgroundColor
@@ -185,8 +176,7 @@ abstract class Display {
      *
      * @return the register type
      */
-    fun getRegisterType() : DisplayHandler.RegisterType = registerType
-
+    fun getRegisterType(): DisplayHandler.RegisterType = registerType
 
     /**
      * Sets the type of register the display will render under.

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayLine.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/display/DisplayLine.kt
@@ -10,6 +10,8 @@ import com.chattriggers.ctjs.triggers.OnTrigger
 import com.chattriggers.ctjs.triggers.TriggerType
 import com.chattriggers.ctjs.utils.kotlin.External
 import com.chattriggers.ctjs.utils.kotlin.NotAbstract
+import com.chattriggers.ctjs.utils.kotlin.getOption
+import com.chattriggers.ctjs.utils.kotlin.getOptionNullable
 import org.mozilla.javascript.NativeObject
 
 @External
@@ -43,16 +45,12 @@ abstract class DisplayLine {
 
     constructor(text: String, config: NativeObject) {
         setText(text)
-
-        textColor = config.getOption("textColor", null)?.toLong()
-        backgroundColor = config.getOption("backgroundColor", null)?.toLong()
-
-        setAlign(config.getOption("align", null))
-        setBackground(config.getOption("background", null))
-    }
-
-    private fun NativeObject?.getOption(key: String, default: Any?): String? {
-        return (this?.get(key) ?: default)?.toString()
+        setTextColor(config.getOptionNullable("textColor", null)?.toLong())
+        setShadow(config.getOption("shadow", false).toBoolean())
+        setScale(config.getOption("scale", 1f).toFloat())
+        setAlign(config.getOptionNullable("align", null))
+        setBackground(config.getOptionNullable("background", null))
+        setBackgroundColor(config.getOptionNullable("backgroundColor", null)?.toLong())
     }
 
     init {

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/Extensions.kt
@@ -3,6 +3,7 @@ package com.chattriggers.ctjs.utils.kotlin
 import com.fasterxml.jackson.core.Version
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import org.mozilla.javascript.NativeObject
 
 fun MCITextComponent.getStyling(): MCTextStyle =
     //#if MC<=10809
@@ -42,9 +43,15 @@ operator fun String.times(times: Number): String {
     return stringBuilder.toString()
 }
 
-inline fun <reified T> Gson.fromJson(json: String) = this.fromJson<T>(json, object : TypeToken<T>() {}.type)
-
 fun String.toVersion(): Version {
     val split = this.split(".").map(String::toInt)
     return Version(split.getOrNull(0) ?: 0, split.getOrNull(1) ?: 0, split.getOrNull(2) ?: 0, null, null, null)
+}
+
+fun NativeObject?.getOption(key: String, default: Any): String {
+    return (this?.get(key) ?: default).toString()
+}
+
+fun NativeObject?.getOptionNullable(key: String, default: Any?): String? {
+    return (this?.get(key) ?: default)?.toString()
 }


### PR DESCRIPTION
This makes it optionally more consistent with Display and DisplayLine.  Had to do .toDouble().toInt() because of casting errors.

Also ordered all the setters for Display and DisplayLine's NativeObject constructors.