### PR TITLE
KeyBind: Re-add clearing & removing keybinds, …

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
@@ -6,7 +6,7 @@ import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.libs.renderer.Renderer
 import com.chattriggers.ctjs.minecraft.listeners.MouseListener
 import com.chattriggers.ctjs.minecraft.objects.display.DisplayHandler
-import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBindHandler
+import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBind
 import com.chattriggers.ctjs.minecraft.objects.message.Message
 import com.chattriggers.ctjs.minecraft.wrappers.Client
 import com.chattriggers.ctjs.minecraft.wrappers.World
@@ -39,11 +39,11 @@ object Reference {
         DisplayHandler.clearDisplays()
         ModuleManager.teardown()
         MouseListener.clearListeners()
-        KeyBindHandler.clearKeyBinds()
+        KeyBind.clearKeyBinds()
 
         Command.activeCommands.values.toList().forEach(Command::unregister)
 
-        Client.getMinecraft().addScheduledTask { 
+        Client.getMinecraft().addScheduledTask {
             CTJS.images.forEach { it.getTexture().deleteGlTexture() }
             CTJS.images.clear()
         }
@@ -118,4 +118,5 @@ object Reference {
 fun Any.printToConsole(console: Console = ModuleManager.generalConsole, logType: LogType = LogType.INFO) {
     console.println(this, logType)
 }
+
 fun Throwable.printTraceToConsole(console: Console = ModuleManager.generalConsole) = console.printStackTrace(this)

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/Impl.kt
@@ -6,6 +6,7 @@ import com.chattriggers.ctjs.minecraft.objects.display.Display
 import com.chattriggers.ctjs.minecraft.objects.display.DisplayLine
 import com.chattriggers.ctjs.minecraft.objects.gui.Gui
 import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBind
+import com.chattriggers.ctjs.minecraft.objects.keybind.KeyBindHandler
 import com.chattriggers.ctjs.minecraft.wrappers.Client
 import net.minecraft.client.settings.KeyBinding
 import org.mozilla.javascript.NativeObject
@@ -51,16 +52,15 @@ class JSKeyBind : KeyBind {
 
 object JSClient : Client() {
     override fun getKeyBindFromKey(keyCode: Int): KeyBind? {
-        return getMinecraft().gameSettings.keyBindings
-            .firstOrNull { it.keyCode == keyCode }
-            ?.let(::JSKeyBind)
+        return KeyBindHandler.getKeyBinds()
+            .find { it.getKeyCode() == keyCode }
+            ?: getMinecraft().gameSettings.keyBindings
+                .find { it.keyCode == keyCode }
+                ?.let(::JSKeyBind)
     }
 
     override fun getKeyBindFromKey(keyCode: Int, description: String, category: String): KeyBind {
-        return getMinecraft().gameSettings.keyBindings
-            .firstOrNull { it.keyCode == keyCode }
-            ?.let(::JSKeyBind)
-            ?: JSKeyBind(description, keyCode, category)
+        return getKeyBindFromKey(keyCode) ?: JSKeyBind(description, keyCode, category)
     }
 
     override fun getKeyBindFromKey(keyCode: Int, description: String): KeyBind {
@@ -68,9 +68,11 @@ object JSClient : Client() {
     }
 
     override fun getKeyBindFromDescription(description: String): KeyBind? {
-        return getMinecraft().gameSettings.keyBindings
-            .firstOrNull { it.keyDescription == description }
-            ?.let(::JSKeyBind)
+        return KeyBindHandler.getKeyBinds()
+            .find { it.getDescription() == description }
+            ?: getMinecraft().gameSettings.keyBindings
+                .find { it.keyDescription == description }
+                ?.let(::JSKeyBind)
     }
 
     val currentGui = Client.Companion.currentGui

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBindHandler.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBindHandler.kt
@@ -4,25 +4,39 @@ import com.chattriggers.ctjs.minecraft.wrappers.World
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal object KeyBindHandler {
     init {
         MinecraftForge.EVENT_BUS.register(this)
     }
 
-    private val keyBinds = mutableListOf<KeyBind>()
+    private val keyBinds = CopyOnWriteArrayList<KeyBind>()
 
     fun registerKeyBind(keyBind: KeyBind) {
         keyBinds.add(keyBind)
     }
 
+    fun unregisterKeyBind(keyBind: KeyBind) {
+        keyBinds.remove(keyBind)
+    }
+
     fun clearKeyBinds() = keyBinds.clear()
+
+    fun getKeyBinds() = keyBinds
 
     @SubscribeEvent
     fun onTick(event: TickEvent.ClientTickEvent) {
-        if (World.getWorld() == null || event.phase == TickEvent.Phase.END)
+        if (!World.isLoaded() || event.phase == TickEvent.Phase.END)
             return
 
-        keyBinds.forEach(KeyBind::onTick)
+        keyBinds.forEach {
+            // TODO: This causes null pointers rarely, crashing the game.
+            //  Catching solves this for now.
+            try {
+                it.onTick()
+            } catch (ignored: Exception) {
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Client.kt
@@ -18,8 +18,7 @@ import kotlin.math.roundToInt
 
 abstract class Client {
     /**
-     * Get the [KeyBind] from an already existing
-     * Minecraft KeyBinding, otherwise, returns null.
+     * Get the [KeyBind] from an already existing Minecraft KeyBinding, otherwise, returns null.
      *
      * @param keyCode the keycode to search for, see Keyboard below. Ex. Keyboard.KEY_A
      * @return the [KeyBind] from a Minecraft KeyBinding, or null if one doesn't exist
@@ -28,23 +27,33 @@ abstract class Client {
     abstract fun getKeyBindFromKey(keyCode: Int): KeyBind?
 
     /**
-     * Get the [KeyBind] from an already existing
-     * Minecraft KeyBinding, else, return a new one.
+     * Get the [KeyBind] from an already existing Minecraft KeyBinding, else, return a new one.
      *
-     * @param keyCode the keycode to search for, see Keyboard below. Ex. Keyboard.KEY_A
-     * @return the [KeyBind] from a Minecraft KeyBinding, or null if one doesn't exist
+     * @param keyCode the keycode which the keybind will respond to, see Keyboard below. Ex. Keyboard.KEY_A
+     * @param description the description of the keybind
+     * @param category the keybind category the keybind will be in
+     * @return the [KeyBind] from a Minecraft KeyBinding, or a new one if one doesn't exist
      * @see [org.lwjgl.input.Keyboard](http://legacy.lwjgl.org/javadoc/org/lwjgl/input/Keyboard.html)
      */
     abstract fun getKeyBindFromKey(keyCode: Int, description: String, category: String): KeyBind
 
+    /**
+     * Get the [KeyBind] from an already existing Minecraft KeyBinding, else, return a new one.
+     * This will create the [KeyBind] with the default category "ChatTriggers".
+     *
+     * @param keyCode the keycode to search for, see Keyboard below. Ex. Keyboard.KEY_A
+     * @param description the description of the keybind
+     * @return the [KeyBind] from a Minecraft KeyBinding, or a new one if one doesn't exist
+     * @see [org.lwjgl.input.Keyboard](http://legacy.lwjgl.org/javadoc/org/lwjgl/input/Keyboard.html)
+     */
     abstract fun getKeyBindFromKey(keyCode: Int, description: String): KeyBind
 
     /**
      * Get the [KeyBind] from an already existing
-     * Minecraft KeyBinding, else, null.
+     * Minecraft KeyBinding, otherwise, returns null.
      *
-     * @param description the key binding's original description
-     * @return the key bind, or null if one doesn't exist
+     * @param description the description of the keybind
+     * @return the [KeyBind], or null if one doesn't exist
      */
     abstract fun getKeyBindFromDescription(description: String): KeyBind?
 


### PR DESCRIPTION
I also changed to make Client.getKeyBindFrom... methods attempt to return an existing KeyBind before making a new one.  Not sure if this is considered breaking or not but wanted to include it in case it wasn't.

Like my comment says in KeyBindHandler line 34, there were occasional NPE's caused by this, but catching during tick fixes this.  I'm not sure if there's anything we can do about it, since it happened too randomly for me to notice a pattern, and the game works perfectly normal with it.