### PR TITLE
Add author field to module metadata

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
@@ -9,6 +9,7 @@ data class ModuleMetadata(
     val tags: ArrayList<String>? = null,
     val pictureLink: String? = null,
     val creator: String? = null,
+    val author: String? = null,
     val description: String? = null,
     val requires: ArrayList<String>? = null,
     val helpMessage: String? = null,


### PR DESCRIPTION
Since a few people use author (including me) I feel like this is a useful addition. The author/creator field in the metadata is not actually checked anywhere.