### PR TITLE
ClientListener: Fix "high ping" lag with packets

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/langs/js/JSLoader.kt
@@ -199,7 +199,7 @@ object JSLoader : ILoader {
         }
     }
 
-    private inline fun <T> wrapInContext(context: Context = moduleContext, crossinline block: () -> T): T {
+    internal inline fun <T> wrapInContext(context: Context = moduleContext, crossinline block: () -> T): T {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
         }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/listeners/ClientListener.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.minecraft.listeners
 
 import com.chattriggers.ctjs.engine.langs.js.JSContextFactory
+import com.chattriggers.ctjs.engine.langs.js.JSLoader
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.minecraft.libs.EventLib
 import com.chattriggers.ctjs.minecraft.wrappers.Client
@@ -36,11 +37,14 @@ object ClientListener {
     val chatHistory = mutableListOf<String>()
     val actionBarHistory = mutableListOf<String>()
     private val tasks = CopyOnWriteArrayList<Task>()
+    private var packetContext: Context
 
     class Task(var delay: Int, val callback: () -> Unit)
 
     init {
         ticksPassed = 0
+        packetContext = JSContextFactory.enterContext()
+        Context.exit()
     }
 
     @SubscribeEvent
@@ -110,11 +114,8 @@ object ClientListener {
                     val packetReceivedEvent = CancellableEvent()
 
                     if (msg is Packet<*>) {
-                        JSContextFactory.enterContext()
-                        try {
+                        JSLoader.wrapInContext(packetContext) {
                             TriggerType.PacketReceived.triggerAll(msg, packetReceivedEvent)
-                        } finally {
-                            Context.exit()
                         }
                     }
 
@@ -126,11 +127,8 @@ object ClientListener {
                     val packetSentEvent = CancellableEvent()
 
                     if (msg is Packet<*>) {
-                        JSContextFactory.enterContext()
-                        try {
+                        JSLoader.wrapInContext(packetContext) {
                             TriggerType.PacketSent.triggerAll(msg, packetSentEvent)
-                        } finally {
-                            Context.exit()
                         }
                     }
 


### PR DESCRIPTION
Previously, playing on certain servers (e.g. Hypixel's housing lobby), players would have to wait sometimes 30 seconds or longer to move around and open menus without being rubberbanded back.  Somehow this was due to the packet "fix" I added a couple of months ago, but I'm still not sure why it would cause so much lag like that.  I'm not really sure why that caused so much lag, but it might have been an issue with Rhino attempting to create a context for every packet sent and received, but that doesn't make sense since it should store and reuse contexts for the same thread.