### PR TITLE
Add image.destroy method

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
@@ -43,7 +43,7 @@ object CTJS {
     val configLocation = File("./config")
     val assetsDir = File(configLocation, "ChatTriggers/images/").apply { mkdirs() }
     val sounds = mutableListOf<Sound>()
-    val images = mutableListOf<Image>()
+    val images = mutableSetOf<Image>()
 
     @Mod.EventHandler
     fun preInit(event: FMLPreInitializationEvent) {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Image.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/renderer/Image.kt
@@ -49,6 +49,15 @@ class Image constructor(var image: BufferedImage?) {
         return texture
     }
 
+    /**
+     * Clears the image from GPU memory and removes its references CT side
+     * that way it can be garbage collected if not referenced in js code.
+     */
+    fun destroy() {
+        texture.deleteGlTexture()
+        CTJS.images.remove(this)
+    }
+
     @SubscribeEvent
     fun onRender(event: RenderGameOverlayEvent.Pre) {
         if (image != null) {


### PR DESCRIPTION
At the moment images only get garbage collected after a ct load, this can cause a memory leak if the images are no longer used from the js side.

So the idea is before u remove references to an images in js side u call image.destroy() and that will clear all references to it in the CT code so that its able to be garbage collected.
It also deletes the gl texture that way its removed from GPU ram