### PR TITLE
Reference: Allow to /ct load after /ct unload'ing

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
@@ -50,14 +50,11 @@ object Reference {
 
         if (asCommand) {
             ChatLib.chat("&7Unloaded all of ChatTriggers")
-            isLoaded = false
         }
     }
 
     @JvmStatic
     fun loadCT() {
-        if (!isLoaded) return
-
         Client.getMinecraft().gameSettings.saveOptions()
         unloadCT(false)
 


### PR DESCRIPTION
Previously users would have to restart their game if they executed /ct unload.