### PR TITLE
Add clicking links automatically for TextComponent & a couple bug fixes

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
@@ -53,7 +53,7 @@ class Module(val name: String, var metadata: ModuleMetadata, val folder: File) {
             }
 
             Renderer.drawStringWithShadow(
-                ChatLib.addColor(if (metadata.isRequired) {
+                ChatLib.addColor(if (metadata.isRequired && requiredBy.isNotEmpty()) {
                     "&8required by $requiredBy"
                 } else {
                     "&4[delete]"
@@ -73,7 +73,7 @@ class Module(val name: String, var metadata: ModuleMetadata, val folder: File) {
             return
         }
 
-        if (gui.collapsed || metadata.isRequired) return
+        if (gui.collapsed || (metadata.isRequired && requiredBy.isNotEmpty())) return
 
         if (x > gui.x && x < gui.x + 45
             && y > gui.y + gui.description.getHeight() + 15 && y < gui.y + gui.description.getHeight() + 25

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleUpdater.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleUpdater.kt
@@ -99,7 +99,7 @@ object ModuleUpdater {
 
     fun importModule(moduleName: String, requiredBy: String? = null): List<Module> {
         val alreadyImported = cachedModules.any {
-            if (it.name == moduleName) {
+            if (it.name.equals(moduleName, ignoreCase = true)) {
                 if (requiredBy != null) {
                     it.metadata.isRequired = true
                     it.requiredBy.add(requiredBy)

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/message/TextComponent.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/message/TextComponent.kt
@@ -2,6 +2,7 @@ package com.chattriggers.ctjs.minecraft.objects.message
 
 import com.chattriggers.ctjs.minecraft.libs.ChatLib
 import com.chattriggers.ctjs.utils.kotlin.*
+import net.minecraftforge.common.ForgeHooks
 
 class TextComponent {
 
@@ -186,10 +187,9 @@ class TextComponent {
                 "}"
 
     private fun reInstance() {
-        chatComponentText = MCBaseTextComponent(
-            if (formatted) ChatLib.addColor(text)
-            else text
-        )
+        val string = if (formatted) ChatLib.addColor(text) else text
+
+        chatComponentText = ForgeHooks.newChatWithLinks(string)
 
         reInstanceClick()
         reInstanceHover()


### PR DESCRIPTION
Adds support for automatically adding clicking to links in TextComponents, most notably seen in ChatLib.chat, but also in other areas.

Also fixed a couple of bugs with ModulesGui:
- Now won't create multiple copies of the module in the gui if the casing in the requires array is incorrect.
- Also now allows deleting if the module had dependents but not anymore