### PR TITLE
Fix ChatLib.say not triggering MessageSent

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/CTJSTransformer.kt
@@ -39,6 +39,7 @@ class CTJSTransformer : BaseClassTransformer() {
             injectGuiIngame()
             injectGuiIngameForge()
             injectRenderItem()
+            injectEntityPlayerSP()
             ModuleManager.setup()
             ModuleManager.asmPass()
         } catch (e: Throwable) {

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/entityPlayerSP.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/entityPlayerSP.kt
@@ -1,0 +1,33 @@
+package com.chattriggers.ctjs.launch.plugin
+
+import com.chattriggers.ctjs.minecraft.listeners.CancellableEvent
+import com.chattriggers.ctjs.triggers.TriggerType
+import dev.falsehonesty.asmhelper.dsl.At
+import dev.falsehonesty.asmhelper.dsl.InjectionPoint
+import dev.falsehonesty.asmhelper.dsl.code.CodeBlock
+import dev.falsehonesty.asmhelper.dsl.inject
+
+fun injectEntityPlayerSP() {
+    injectSendChatMessage()
+}
+
+fun injectSendChatMessage() = inject {
+    className = "net/minecraft/client/entity/EntityPlayerSP"
+    methodName = "sendChatMessage"
+    methodDesc = "(Ljava/lang/String;)V"
+    at = At(InjectionPoint.HEAD)
+
+    methodMaps = mapOf("func_71165_d" to "sendChatMessage")
+
+    codeBlock {
+        val local1 = shadowLocal<String>()
+
+        code {
+            val event = CancellableEvent()
+            TriggerType.MessageSent.triggerAll(local1, event)
+
+            if (event.isCancelled())
+                CodeBlock.methodReturn()
+        }
+    }
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiScreen.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiScreen.kt
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack
 import org.lwjgl.input.Keyboard
 
 fun injectGuiScreen() {
-    injectSendChatMessage()
     injectHandleKeyboardInput()
     injectMouseClick()
     injectMouseRelease()
@@ -25,27 +24,6 @@ fun injectGuiScreen() {
     injectTextComponentHover()
     injectRenderTooltip()
     injectPreBackground()
-}
-
-fun injectSendChatMessage() = inject {
-    className = "net/minecraft/client/gui/GuiScreen"
-    methodName = "sendChatMessage"
-    methodDesc = "(Ljava/lang/String;Z)V"
-    at = At(InjectionPoint.HEAD)
-
-    methodMaps = mapOf("func_175281_b" to "sendChatMessage")
-
-    codeBlock {
-        val local1 = shadowLocal<String>()
-
-        code {
-            val event = CancellableEvent()
-            TriggerType.MessageSent.triggerAll(local1, event)
-
-            if (event.isCancelled())
-                methodReturn()
-        }
-    }
 }
 
 fun injectHandleKeyboardInput() = inject {


### PR DESCRIPTION
The old injection point was at `GuiChat.sendChatMessage` which meant `ChatLib.say` wouldn't trigger the event as it's calling `EntityPlayerSP.sendChatMessage`. `GuiChat.sendChatMessage` calls `EntityPlayerSP.sendChatMessage` as well behind the scenes.