### PR TITLE
ModuleManager: don't use vigilance to get modules folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ repositories {
 
 dependencies {
     provided "gg.essential:loader-launchwrapper:1.1.3"
-    implementation "gg.essential:essential-1.8.9-forge:2487"
+    implementation "gg.essential:essential-1.8.9-forge:11092+gecb85a783"
 
     provided("dev.falsehonesty.asmhelper:AsmHelper:1.5.3-$mcVersion") {
         exclude group: "org.jetbrains.kotlin"

--- a/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/CTJS.kt
@@ -63,8 +63,7 @@ object CTJS {
 
     @Mod.EventHandler
     fun init(event: FMLInitializationEvent) {
-        Vigilance.initialize()
-        Config.preload()
+        Config.loadData()
 
         // Ensure that reportHashedUUID always runs on a separate thread
         if (Config.threadedLoading) {

--- a/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
@@ -23,6 +23,8 @@ object Reference {
     const val MODNAME = "ChatTriggers"
     const val MODVERSION = "2.1.5"
 
+    const val DEFAULT_MODULES_FOLDER = "./config/ChatTriggers/modules"
+
     var isLoaded = true
 
     @Deprecated("Does not provide any additional functionality", ReplaceWith("loadCT"))

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/Config.kt
@@ -1,6 +1,7 @@
 package com.chattriggers.ctjs.utils
 
 import com.chattriggers.ctjs.CTJS
+import com.chattriggers.ctjs.Reference
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Property
 import gg.essential.vigilance.data.PropertyType
@@ -8,13 +9,15 @@ import java.awt.Color
 import java.io.File
 
 object Config : Vigilant(File(CTJS.configLocation, "ChatTriggers.toml"), sortingBehavior = CategorySorting) {
+    // Do not change the name or category of this option without also updating the
+    // code in the ModuleManager#modulesFolder initializer.
     @Property(
         PropertyType.TEXT,
         name = "Modules Folders",
         category = "General",
         description = "Folder where CT modules are stored",
     )
-    var modulesFolder: String = "./config/ChatTriggers/modules"
+    var modulesFolder: String = Reference.DEFAULT_MODULES_FOLDER
 
     @Property(
         PropertyType.SWITCH,


### PR DESCRIPTION
This avoids some strange edge cases with LaunchWrapper and avoids accidentally loading minecraft classes from a coremod.