### PR TITLE
ChatLib: Fix editChat overflowing & a bunch of other issues

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/libs/ChatLib.kt
@@ -251,11 +251,10 @@ object ChatLib {
     }
 
     private fun editChat(toReplace: (Message) -> Boolean, vararg replacements: Message) {
-        val drawnChatLines = Client.getChatGUI()!!.drawnChatLines
         val chatLines = Client.getChatGUI()!!.chatLines
 
         editChatLineList(chatLines, toReplace, *replacements)
-        editChatLineList(drawnChatLines, toReplace, *replacements)
+        Client.getChatGUI()!!.refreshChat()
     }
 
     private fun editChatLineList(
@@ -343,11 +342,10 @@ object ChatLib {
     }
 
     private fun deleteChat(toDelete: (Message) -> Boolean) {
-        val drawnChatLines = Client.getChatGUI()!!.drawnChatLines
         val chatLines = Client.getChatGUI()!!.chatLines
 
         deleteChatLineList(chatLines, toDelete)
-        deleteChatLineList(drawnChatLines, toDelete)
+        Client.getChatGUI()!!.refreshChat()
     }
 
     private fun deleteChatLineList(

--- a/src/main/resources/ctjs_at.cfg
+++ b/src/main/resources/ctjs_at.cfg
@@ -1,5 +1,4 @@
 public net.minecraft.client.gui.GuiNewChat field_146252_h           # chatLines
-public net.minecraft.client.gui.GuiNewChat field_146253_i           # drawnChatLines
 public net.minecraft.client.gui.ChatLine field_74542_c              # chatLineID
 public net.minecraft.client.gui.ChatLine field_74541_b              # lineString
 public net.minecraft.client.particle.EntityFX field_70547_e         # particleMaxAge


### PR DESCRIPTION
Now only modifies the chatLines field, which when calling  GuiNewChat::refreshChat, will update all drawn lines accordlingly.