### PR TITLE
Triggers: Add EntityRenderTrigger with dedicated class filter.

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/IRegister.kt
@@ -1128,12 +1128,14 @@ interface IRegister {
      *
      * Available modifications:
      * - [Trigger.setPriority] Sets the priority
+     * - [EntityRenderTrigger.setEntityClasses] Sets the entity classes which this trigger
+     *   gets fired for
      *
      * @param method The method to call when the event is fired
      * @return The trigger for additional modification
      */
-    fun registerRenderEntity(method: Any): EventTrigger {
-        return EventTrigger(method, TriggerType.RenderEntity, getImplementationLoader())
+    fun registerRenderEntity(method: Any): EntityRenderTrigger {
+        return EntityRenderTrigger(method, TriggerType.RenderEntity, getImplementationLoader())
     }
 
     /**
@@ -1146,12 +1148,14 @@ interface IRegister {
      *
      * Available modifications:
      * - [Trigger.setPriority] Sets the priority
+     * - [EntityRenderTrigger.setEntityClasses] Sets the entity classes which this trigger
+     *   gets fired for
      *
      * @param method The method to call when the event is fired
      * @return The trigger for additional modification
      */
-    fun registerPostRenderEntity(method: Any): RegularTrigger {
-        return RegularTrigger(method, TriggerType.PostRenderEntity, getImplementationLoader())
+    fun registerPostRenderEntity(method: Any): EntityRenderTrigger {
+        return EntityRenderTrigger(method, TriggerType.PostRenderEntity, getImplementationLoader())
     }
 
     /**

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/EntityRenderTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/EntityRenderTrigger.kt
@@ -1,0 +1,29 @@
+package com.chattriggers.ctjs.triggers
+
+import com.chattriggers.ctjs.engine.ILoader
+import com.chattriggers.ctjs.minecraft.wrappers.entity.Entity
+
+class EntityRenderTrigger(method: Any, triggerType: TriggerType, loader: ILoader): Trigger(method, triggerType, loader) {
+    private var triggerClasses: List<Class<*>> = emptyList()
+
+    /**
+     * Alias for `setEntityClasses([class_])`
+     */
+    fun setEntityClass(class_: Class<*>?) = setEntityClasses(listOfNotNull(class_))
+
+    /**
+     * Sets which classes this Trigger should run for. If the list is empty, it runs
+     * for every entity class.
+     *
+     * @param classes The classes for which this trigger should run for
+     * @return This trigger object for entity chaining
+     */
+    fun setEntityClasses(classes: List<Class<*>>) = apply { triggerClasses = classes }
+
+    override fun trigger(args: Array<out Any?>) {
+        val entity = args.getOrNull(0) as? Entity
+            ?: error("Expected first argument of renderEntity trigger to be instance of Entity<*> class")
+        if(triggerClasses.isEmpty() || triggerClasses.any { it.isInstance(entity.entity) })
+            callMethod(args)
+    }
+}


### PR DESCRIPTION
This is based on the PacketTrigger, since often when the `renderEntity` Trigger is used there is just a check if the entity which is rendered has the right class (and returned otherwise) before any modification happens. This leads to a lot of calls that dont have any use except returning