### PR TITLE
ModuleManager: Load jars on import

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/commands/Command.kt
@@ -60,7 +60,7 @@ class Command(
     //#endif
 
     fun register() {
-        if (name in ClientCommandHandler.instance.commandMap.keys && !overrideExisting) {
+        if (name in ClientCommandHandler.instance.commands.keys && !overrideExisting) {
             ("Command with name $name already exists! " +
                     "This will not override the other command with the same name. " +
                     "To override conflicting commands, " +
@@ -75,7 +75,7 @@ class Command(
 
     fun unregister() {
         ClientCommandHandler.instance.commandSet.remove(this)
-        ClientCommandHandler.instance.commandMap.remove(name)
+        ClientCommandHandler.instance.commands.remove(name)
         activeCommands.remove(name)
     }
 

--- a/src/main/resources/ctjs_at.cfg
+++ b/src/main/resources/ctjs_at.cfg
@@ -1,13 +1,10 @@
 public net.minecraft.client.gui.GuiNewChat field_146252_h           # chatLines
-public net.minecraft.client.gui.ChatLine field_74542_c              # chatLineID
-public net.minecraft.client.gui.ChatLine field_74541_b              # lineString
 public net.minecraft.client.particle.EntityFX field_70547_e         # particleMaxAge
 public net.minecraft.client.gui.GuiChat field_146415_a              # inputField
 public net.minecraft.client.gui.GuiPlayerTabOverlay field_175256_i  # header
 public net.minecraft.client.gui.GuiPlayerTabOverlay field_175255_h  # footer
 public net.minecraft.client.audio.SoundHandler field_147694_f       # sndManager
 public net.minecraft.command.CommandHandler field_71561_b           # commandSet
-public net.minecraft.command.CommandHandler field_71562_a           # commandMap
 public net.minecraft.nbt.NBTTagCompound field_74784_a               # tagMap
 public net.minecraft.client.gui.GuiScreenBook field_146483_y        # bookPages
 public net.minecraft.client.gui.GuiScreenBook field_146484_x        # currPage


### PR DESCRIPTION
Also removes 3 access transformers.  Only 1 is noticibly changed in the code since the other 2 getters were named get{field}.