### PR TITLE
NBT: Add fromJson methods

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBT.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBT.kt
@@ -1,0 +1,125 @@
+package com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt
+
+import com.chattriggers.ctjs.utils.kotlin.MCNBTBase
+import com.chattriggers.ctjs.utils.kotlin.MCNBTTagCompound
+import com.chattriggers.ctjs.utils.kotlin.MCNBTTagList
+import com.chattriggers.ctjs.utils.kotlin.getOption
+import net.minecraft.nbt.*
+import org.mozilla.javascript.NativeArray
+import org.mozilla.javascript.NativeObject
+
+object NBT {
+    /**
+     * Creates a new [NBTBase] from the given [nbt]
+     *
+     * @param nbt the value to convert to NBT
+     * @param options optional argument to allow refinement of the NBT data.
+     * Possible options include:
+     * - coerceNumericStrings: Boolean, default false.
+     * E.g. "10b" as a byte, "20s" as a short, "30f" as a float, "40d" as a double,
+     * "50l" as a long
+     * - preferArraysOverLists: Boolean, default false
+     * E.g. a list with all bytes or integers will be converted to an NBTTagByteArray or
+     * NBTTagIntArray accordingly
+     *
+     * @throws [NBTException] if [nbt] can not be parsed as valid NBT
+     *
+     * @return [NBTTagCompound] if [nbt] is an object, [NBTTagList] if [nbt]
+     * is an array and preferArraysOverLists is false, or [NBTBase] otherwise.
+     */
+    @JvmOverloads
+    @JvmStatic
+    @Throws(NBTException::class)
+    fun parse(nbt: Any, options: NativeObject? = null): NBTBase {
+        return when (nbt) {
+            is NativeObject -> NBTTagCompound(nbt.toNBT(options) as MCNBTTagCompound)
+            is NativeArray -> {
+                nbt.toNBT(options).let {
+                    if (it is MCNBTTagList) {
+                        NBTTagList(it)
+                    } else {
+                        NBTBase(it)
+                    }
+                }
+            }
+            else -> NBTBase(nbt.toNBT(options))
+        }
+    }
+
+    @JvmStatic
+    fun toObject(nbt: NBTTagCompound): NativeObject = nbt.toObject()
+
+    @JvmStatic
+    fun toArray(nbt: NBTTagList): NativeArray = nbt.toArray()
+
+    @Throws(NBTException::class)
+    private fun Any.toNBT(options: NativeObject?): MCNBTBase {
+        val preferArraysOverLists = options.getOption("preferArraysOverLists", false).toBoolean()
+        val coerceNumericStrings = options.getOption("coerceNumericStrings", false).toBoolean()
+
+        return when (this) {
+            is NativeObject -> MCNBTTagCompound().apply {
+                entries.forEach { entry ->
+                    tagMap[entry.key.toString()] = entry.value.toNBT(options)
+                }
+            }
+            is NativeArray -> {
+                val normalized = map { it?.toNBT(options) }
+
+                if (!preferArraysOverLists || normalized.isEmpty()) {
+                    return MCNBTTagList().apply { tagList = normalized }
+                }
+
+                return when {
+                    (normalized.all { it is NBTTagByte }) -> {
+                        NBTTagByteArray(normalized.map { (it as NBTTagByte).byte }.toByteArray())
+                    }
+
+                    (normalized.all { it is NBTTagInt }) -> {
+                        NBTTagIntArray(normalized.map { (it as NBTTagInt).int }.toIntArray())
+                    }
+
+                    else -> MCNBTTagList().apply { tagList = normalized }
+                }
+            }
+            is Boolean -> NBTTagByte(if (this) 1 else 0)
+            is String -> parseString(this, coerceNumericStrings)
+            is Byte -> NBTTagByte(this)
+            is Short -> NBTTagShort(this)
+            is Int -> NBTTagInt(this)
+            is Long -> NBTTagLong(this)
+            is Float -> NBTTagFloat(this)
+            is Double -> NBTTagDouble(this)
+            else -> throw NBTException("Invalid NBT. Value provided: $this")
+        }
+    }
+
+    private val numberNBTFormat = Regex("^([+-]?\\d+\\.?\\d*)([bslfd])?\$", RegexOption.IGNORE_CASE)
+
+    private fun parseString(nbtData: String, coerceNumericStrings: Boolean): MCNBTBase {
+        if (!coerceNumericStrings) {
+            return NBTTagString(nbtData)
+        }
+
+        val res = numberNBTFormat.matchEntire(nbtData)?.groupValues ?: return NBTTagString(nbtData)
+
+        val number = res[1]
+        val suffix = res[2]
+
+        return when (suffix.lowercase()) {
+            "" -> {
+                if (number.contains(".")) {
+                    NBTTagDouble(number.toDouble())
+                } else {
+                    NBTTagInt(number.toInt())
+                }
+            }
+            "b" -> NBTTagByte(number.toByte())
+            "s" -> NBTTagShort(number.toShort())
+            "l" -> NBTTagLong(number.toLong())
+            "f" -> NBTTagFloat(number.toFloat())
+            "d" -> NBTTagDouble(number.toDouble())
+            else -> NBTTagString(nbtData)
+        }
+    }
+}

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagCompound.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagCompound.kt
@@ -164,7 +164,5 @@ class NBTTagCompound(override val rawNBT: MCNBTTagCompound) : NBTBase(rawNBT) {
         rawNBT.removeTag(key)
     }
 
-    fun toObject(): NativeObject {
-        return rawNBT.toObject()
-    }
+    fun toObject(): NativeObject = rawNBT.toObject()
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagList.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/inventory/nbt/NBTTagList.kt
@@ -2,6 +2,7 @@ package com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt
 
 import com.chattriggers.ctjs.utils.kotlin.MCNBTBase
 import com.chattriggers.ctjs.utils.kotlin.MCNBTTagList
+import org.mozilla.javascript.NativeArray
 
 class NBTTagList(override val rawNBT: MCNBTTagList) : NBTBase(rawNBT) {
     val tagCount: Int
@@ -47,4 +48,6 @@ class NBTTagList(override val rawNBT: MCNBTTagList) : NBTBase(rawNBT) {
         NBTTagCompound.NBTDataType.COMPOUND_TAG -> getCompoundTagAt(index)
         else -> get(index)
     }
+
+    fun toArray(): NativeArray = rawNBT.toObject()
 }

--- a/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/utils/kotlin/Extensions.kt
@@ -51,7 +51,3 @@ fun String.toVersion(): Version {
 fun NativeObject?.getOption(key: String, default: Any): String {
     return (this?.get(key) ?: default).toString()
 }
-
-fun NativeObject?.getOptionNullable(key: String, default: Any?): String? {
-    return (this?.get(key) ?: default)?.toString()
-}

--- a/src/main/resources/js/moduleProvidedLibs.js
+++ b/src/main/resources/js/moduleProvidedLibs.js
@@ -89,6 +89,7 @@
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.action.DropAction");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.action.KeyAction");
 
+    loadInstance("com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt.NBT");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt.NBTBase");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt.NBTTagCompound");
     loadClass("com.chattriggers.ctjs.minecraft.wrappers.inventory.nbt.NBTTagList");


### PR DESCRIPTION
This allows users to create NBT wrappers similar to how they can create objects in the other direction. Users can pass numbers with the letter of the type that they should be, "1s" will be parsed as the short value 1, etc.  This also attempts to pack arrays into NBTTag(Byte, Int)Array if every element in each is a valid byte/int (or a string parsed as one).

Marking this as draft for now due to some issues.

- Right now NBTTagList::fromJson will throw a class cast exception if it tries to make a list with only floats/bytes, where it will interpret and parse them as a NBTTag(Byte, Int)Array.  Right now, it seems that there should be a way for the user to specify if they want the typed tag array instead of the normal taglist, but I haven't found a good answer to that yet.
- I'm not entirely sure if NBT can have null values, so if not, then what do we do?  Throw an error or just ignore that key?  I'd say throwing an error would be better.
- Also as I'm writing this, I found that TagLists are only supposed to have 1 type inside them [from this link](http://web.archive.org/web/20110723210920/http://www.minecraft.net/docs/NBT.txt), so I'll have to add a check to that as well.
  - This is likely considered a breaking change, but we can consider adding the checks like MC does for setting values in the list would fix the bug that allows different types into the list