### PR TITLE
KeyBind: fix registered triggers not unregistering correctly

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBind.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/objects/keybind/KeyBind.kt
@@ -74,6 +74,21 @@ abstract class KeyBind {
         onKeyDown
     }
 
+    fun unregisterKeyPress() = apply {
+        onKeyPress?.unregister()
+        onKeyPress = null
+    }
+
+    fun unregisterKeyRelease() = apply {
+        onKeyRelease?.unregister()
+        onKeyRelease = null
+    }
+
+    fun unregisterKeyDown() = apply {
+        onKeyDown?.unregister()
+        onKeyDown = null
+    }
+
     internal fun onTick() {
         if (isPressed()) {
             onKeyPress?.trigger(arrayOf())


### PR DESCRIPTION
This fixes the issue mentioned here: https://discord.com/channels/119493402902528000/688773480954855537/1073933069725224980
and the resulting conversation related to the same issue: https://discord.com/channels/119493402902528000/688773480954855537/1074072830024622100
The changes now return the Keybind itself from the functions since the `RegularTrigger` does not offer important ways to change the behaviour of the trigger except priority which I have never seen being used, especially in this case.
Also `Keybind.registerKeyPress(whateverFunc).registerKeyDown(anotherFunc)` would be possible now which was not the case before.