### PR TITLE
BlockPos: Add getAllInBox method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.dokka'
 
-version = "2.1.5-" + (
+version = "2.2.0-" + (
     mcVersion.toString().substring(0, 1) + "." +
         mcVersion.toString().substring(1, 3).replace("0", "") + "." +
         mcVersion.toString().substring(3, 5).replace("0", "")

--- a/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/Reference.kt
@@ -21,7 +21,7 @@ import kotlin.math.roundToInt
 object Reference {
     const val MODID = "chattriggers"
     const val MODNAME = "ChatTriggers"
-    const val MODVERSION = "2.1.5"
+    const val MODVERSION = "2.2.0"
 
     const val DEFAULT_MODULES_FOLDER = "./config/ChatTriggers/modules"
 

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockPos.kt
@@ -46,5 +46,20 @@ class BlockPos(x: Number, y: Number, z: Number) : Vec3i(x, y, z) {
         return BlockPos(x + facing.getOffsetX() * n, y + facing.getOffsetY() * n, z + facing.getOffsetZ() * n)
     }
 
+    companion object {
+        /**
+         * Gets a list of [BlockPos] within the Box.
+         *
+         * @param from The BlockPos to start at
+         * @param to The BlockPos at the other side of the Box
+         * @return The Blocks including the corners wrapped as ct [BlockPos]
+         */
+        @JvmStatic
+        fun getAllInBox(from: BlockPos, to: BlockPos): List<BlockPos> {
+            return MCBlockPos.getAllInBox(from.toMCBlock(), to.toMCBlock()).map(::BlockPos)
+        }
+    }
+
+
     fun toMCBlock() = MCBlockPos(x, y, z)
 }


### PR DESCRIPTION
This provides an alternative to the method of using nested for loops for x, y, z and the calls to `World.getBlockAt(x, y, z)` just to get Blocks in a certain area.