### PR TITLE
Fix documentation around some methods dealing with blocks

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/Player.kt
@@ -249,10 +249,10 @@ object Player {
 
     /**
      * Gets the current object that the player is looking at,
-     * whether that be a block or an entity. Returns an air block when not looking
+     * whether that be a block or an entity. Returns an air [BlockType] when not looking
      * at anything.
      *
-     * @return the [BlockType], [Sign], or [Entity] being looked at
+     * @return the [Block], [Entity], [Sign], or [BlockType] being looked at
      */
     @JvmStatic
     fun lookingAt(): Any {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/World.kt
@@ -112,21 +112,21 @@ object World {
     }
 
     /**
-     * Gets the [BlockType] at a location in the world.
+     * Gets the [Block] at a location in the world.
      *
      * @param x the x position
      * @param y the y position
      * @param z the z position
-     * @return the [BlockType] at the location
+     * @return the [Block] at the location
      */
     @JvmStatic
     fun getBlockAt(x: Number, y: Number, z: Number) = getBlockAt(BlockPos(x, y, z))
 
     /**
-     * Gets the [BlockType] at a location in the world.
+     * Gets the [Block] at a location in the world.
      *
      * @param pos The block position
-     * @return the [BlockType] at the location
+     * @return the [Block] at the location
      */
     @JvmStatic
     fun getBlockAt(pos: BlockPos): Block {
@@ -137,7 +137,7 @@ object World {
      * Gets the [IBlockState] at a location in the world.
      *
      * @param pos The block position
-     * @return the [BlockType] at the location
+     * @return the [IBlockState] at the location
      */
     @JvmStatic
     fun getBlockStateAt(pos: BlockPos): IBlockState {

--- a/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockType.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/minecraft/wrappers/world/block/BlockType.kt
@@ -20,11 +20,11 @@ class BlockType(val mcBlock: MCBlock) {
     constructor(item: Item) : this(MCBlock.getBlockFromItem(item.item))
 
     /**
-     * Returns a PlacedBlock based on this block and the
+     * Returns a [Block] based on this block and the
      * provided BlockPos
      *
      * @param blockPos the block position
-     * @return a PlacedBlock object
+     * @return a [Block] object
      */
     fun withBlockPos(blockPos: BlockPos) = Block(this, blockPos)
 


### PR DESCRIPTION
This fixes some documentation issues around various methods dealing with the block APIs. They were introduced in the transition to the new APIs at commit 61d87df.