### PR TITLE
Trigger: Fix priorities

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/ForgeTrigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/ForgeTrigger.kt
@@ -28,16 +28,6 @@ class ForgeTrigger(
         return super.unregister()
     }
 
-    override fun setPriority(priority: Priority): Trigger {
-        super.setPriority(priority)
-
-        // Re-register so the position in the SortedSet gets updated
-        unregister()
-        register()
-
-        return this
-    }
-
     override fun trigger(args: Array<out Any?>) {
         callMethod(args)
     }

--- a/src/main/kotlin/com/chattriggers/ctjs/triggers/Trigger.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/triggers/Trigger.kt
@@ -22,8 +22,12 @@ abstract class Trigger protected constructor(
      * @param priority the priority of the trigger
      * @return the trigger for method chaining
      */
-    open fun setPriority(priority: Priority) = apply {
+    fun setPriority(priority: Priority) = apply {
         this.priority = priority
+
+        // Re-register so the position in the ConcurrentSkipListSet gets updated
+        unregister()
+        register()
     }
 
     /**


### PR DESCRIPTION
Java's data structures don't support mutable elements when sorting by natural order, so we have to re-add them to update the ordering.