### PR TITLE
Color dependency modules in gray

### DIFF
--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
@@ -27,7 +27,7 @@ class Module(val name: String, var metadata: ModuleMetadata, val folder: File) {
         )
         
         Renderer.drawStringWithShadow(
-            (metadata.isLibrary===true ? "§7" : "")+(metadata.name ?: name),
+            (metadata.isRequired===true ? "§7" : "")+(metadata.name ?: name),
             x + 3, y + 3
         )
 

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/Module.kt
@@ -25,8 +25,9 @@ class Module(val name: String, var metadata: ModuleMetadata, val folder: File) {
             0xaa000000,
             x, y, width, 13f
         )
+        
         Renderer.drawStringWithShadow(
-            metadata.name ?: name,
+            (metadata.isLibrary===true ? "§7" : "")+(metadata.name ?: name),
             x + 3, y + 3
         )
 

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
@@ -14,5 +14,6 @@ data class ModuleMetadata(
     val helpMessage: String? = null,
     val changelog: String? = null,
     val ignored: ArrayList<String>? = null,
-    var isRequired: Boolean = false
+    var isRequired: Boolean = false,
+    var isLibrary: Boolean = false
 )

--- a/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
+++ b/src/main/kotlin/com/chattriggers/ctjs/engine/module/ModuleMetadata.kt
@@ -15,5 +15,4 @@ data class ModuleMetadata(
     val changelog: String? = null,
     val ignored: ArrayList<String>? = null,
     var isRequired: Boolean = false,
-    var isLibrary: Boolean = false
 )


### PR DESCRIPTION
Added a key that colours modules gray in the module list if the isLibrary metadata key is set to true.